### PR TITLE
Change from Git to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/examples"]
 	path = tests/examples
-	url = git@github.com:cose-wg/Examples.git
+	url = https://github.com/cose-wg/Examples.git


### PR DESCRIPTION
Using Git in the submodules requires a valid GitHub.com SSH key to be able to clone the repository.

This is problematic when using CI tools such as GitLab CI, therefore I suggest using HTTPS to avoid that.

PS: Now pull requesting to the develop branch.