### PR TITLE
Fix: check for Ed[25519/448] signing curves instead of X[25519/448]

### DIFF
--- a/cose/keys/okp.py
+++ b/cose/keys/okp.py
@@ -149,9 +149,9 @@ class OKP(CoseKey):
 
         self._check_key_conf(algorithm=alg, key_operation=KeyOps.SIGN, curve=curve)
 
-        if self.crv == CoseEllipticCurves.X25519:
+        if self.crv == CoseEllipticCurves.ED25519:
             sk = Ed25519PrivateKey.from_private_bytes(self.d)
-        elif self._crv == CoseEllipticCurves.X448:
+        elif self._crv == CoseEllipticCurves.ED448:
             sk = Ed448PrivateKey.from_private_bytes(self.d)
         else:
             raise CoseIllegalCurve(f"Illegal curve for OKP singing: {self.crv}")
@@ -176,9 +176,9 @@ class OKP(CoseKey):
 
         self._check_key_conf(algorithm=alg, key_operation=KeyOps.VERIFY, curve=curve)
 
-        if self.crv == CoseEllipticCurves.X25519:
+        if self.crv == CoseEllipticCurves.ED25519:
             vk = Ed25519PublicKey.from_public_bytes(self.x)
-        elif self._crv == CoseEllipticCurves.X448:
+        elif self._crv == CoseEllipticCurves.ED448:
             vk = Ed448PublicKey.from_public_bytes(self.x)
         else:
             raise CoseIllegalCurve(f"Illegal curve for OKP singing: {self.crv}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,8 +109,8 @@ key_attr_to_be_replaced = {
     "X25519": CoseEllipticCurves.X25519,
     "X448": CoseEllipticCurves.X448,
     "oct": KTY.SYMMETRIC,
-    "Ed448": CoseEllipticCurves.X448,
-    "Ed25519": CoseEllipticCurves.X25519
+    "Ed448": CoseEllipticCurves.ED448,
+    "Ed25519": CoseEllipticCurves.ED25519
 }
 
 


### PR DESCRIPTION
Some broken tests in my application code helped me figure out that the last published version was checking against X25519 and X448 instead of Ed22519 and Ed448 =)