### PR TITLE
Fixing some inconsistencies in attr names.

### DIFF
--- a/cose/keys/cosekey.py
+++ b/cose/keys/cosekey.py
@@ -223,7 +223,7 @@ class CoseKey(metaclass=ABCMeta):
         key_words = ["_kty"]
 
         for kw in argv:
-            if kw.upper() in self.Common.__members__:
+            if kw[1:].upper() in self.Common.__members__:
                 key_words.append(kw)
 
         return {self.Common[kw[1:].upper()]: dataclasses.asdict(self)[kw] for kw in key_words}

--- a/cose/keys/symmetric.py
+++ b/cose/keys/symmetric.py
@@ -61,8 +61,8 @@ class SymmetricKey(CoseKey):
         self._k = new_k
 
     def encode(self, *argv):
-        kws = [kw for kw in argv if self.SymPrm.has_member(kw.upper())]
-        return {**super().encode(*argv), **{self.SymPrm[kw.upper()]: dataclasses.asdict(self)[kw] for kw in kws}}
+        kws = ['_' + kw for kw in argv if self.SymPrm.has_member(kw.upper())]
+        return {**super().encode(*argv), **{self.SymPrm[kw[1:].upper()]: dataclasses.asdict(self)[kw] for kw in kws}}
 
     def encrypt(self, plaintext: bytes, aad: bytes, nonce: bytes, alg: Optional[CoseAlgorithms]) -> bytes:
         self._check_key_conf(alg, KeyOps.ENCRYPT)


### PR DESCRIPTION
This would resolve #32 for at least the base and `SymmetricKey` I haven't tried the other key types.