### PR TITLE
Hash algorithms and x509 fix

### DIFF
--- a/cose/algorithms.py
+++ b/cose/algorithms.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from binascii import hexlify, unhexlify
 from hashlib import sha512, sha384, sha256
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Optional, TypeVar
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
@@ -12,7 +12,7 @@ from cryptography.hazmat.primitives.asymmetric.ed448 import Ed448PrivateKey, Ed4
 from cryptography.hazmat.primitives.ciphers import modes, Cipher
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM, AESCCM
 from cryptography.hazmat.primitives.ciphers.algorithms import AES
-from cryptography.hazmat.primitives.hashes import HashAlgorithm, SHA256, SHA512, SHA384
+from cryptography.hazmat.primitives.hashes import Hash, HashAlgorithm, SHA1, SHA256, SHA512, SHA384, SHAKE128, SHAKE256
 from cryptography.hazmat.primitives.hmac import HMAC
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives.keywrap import aes_key_wrap, aes_key_unwrap
@@ -39,6 +39,28 @@ class CoseAlgorithm(_CoseAttribute, ABC):
     @classmethod
     def get_registered_classes(cls):
         return cls._registered_algorithms
+
+
+class _HashAlg(CoseAlgorithm, ABC):
+    #: Set in derived class to hash constructor
+    hash_cls = None
+    #: Set in derived class to optional trucation size in byte count
+    truc_size: Optional[int] = None
+
+    @classmethod
+    def get_hash_func(cls) -> HashAlgorithm:
+        return cls.hash_cls()
+
+    @classmethod
+    def compute_hash(cls, data: bytes) -> bytes:
+        h = Hash(algorithm=cls.get_hash_func(), backend=default_backend())
+        h.update(data)
+        digest = h.finalize()
+
+        if cls.truc_size:
+            digest = digest[:cls.truc_size]
+
+        return digest
 
 
 class _EncAlg(CoseAlgorithm, ABC):
@@ -232,6 +254,27 @@ class _AesCcm(_EncAlg, ABC):
 ##################################################
 
 @CoseAlgorithm.register_attribute()
+class Shake256(_HashAlg):
+    identifier = -45
+    fullname = "SHAKE-256"
+    hash_cls = SHAKE256
+
+
+@CoseAlgorithm.register_attribute()
+class Sha512(_HashAlg):
+    identifier = -44
+    fullname = "SHA-512"
+    hash_cls = SHA512
+
+
+@CoseAlgorithm.register_attribute()
+class Sha384(_HashAlg):
+    identifier = -43
+    fullname = "SHA-384"
+    hash_cls = SHA384
+
+
+@CoseAlgorithm.register_attribute()
 class Es512(_Ecdsa):
     identifier = -36
     fullname = "ES512"
@@ -421,6 +464,43 @@ class EcdhEsHKDF256(_EcdhHkdf):
     @classmethod
     def get_key_wrap_func(cls):
         return Direct()
+
+
+@CoseAlgorithm.register_attribute()
+class Shake128(_HashAlg):
+    identifier = -18
+    fullname = "SHAKE-128"
+    hash_cls = SHAKE128
+
+
+@CoseAlgorithm.register_attribute()
+class Sha512Trunc256(_HashAlg):
+    identifier = -17
+    fullname = "SHA-512/256"
+    hash_cls = SHA512
+    truc_size = 32
+
+
+@CoseAlgorithm.register_attribute()
+class Sha256(_HashAlg):
+    identifier = -16
+    fullname = "SHA-256"
+    hash_cls = SHA256
+
+
+@CoseAlgorithm.register_attribute()
+class Sha256Trunc64(_HashAlg):
+    identifier = -15
+    fullname = "SHA-256/64"
+    hash_cls = SHA256
+    truc_size = 8
+
+
+@CoseAlgorithm.register_attribute()
+class Sha1(_HashAlg):
+    identifier = -14
+    fullname = "SHA-1"
+    hash_cls = SHA1
 
 
 @CoseAlgorithm.register_attribute()

--- a/cose/extensions/x509.py
+++ b/cose/extensions/x509.py
@@ -1,9 +1,8 @@
-from typing import List, Union
-
-from cryptography.hazmat.backends import openssl
+from typing import List, Set, Union
+from datetime import datetime
+from certvalidator import CertificateValidator, ValidationContext
 
 from cose.algorithms import CoseAlg, CoseAlgorithm
-from cose.headers import CoseAttr
 
 
 class X5Bag:
@@ -76,9 +75,13 @@ class X5Chain:
         if verify:
             self.verify_chain()
 
-    def verify_chain(self):
-        # TODO: verify certificate chain
-        pass
+    def verify_chain(self, ctx: ValidationContext, key_usage: Set[str]):
+        val = CertificateValidator(
+            end_entity_cert=self.cert_chain[0],
+            intermediate_certs=self.cert_chain[1:],
+            validation_context=ctx
+        )
+        return val.validate_usage(key_usage)
 
     def encode(self) -> Union[bytes, List[bytes]]:
         return self.cert_chain

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ cryptography
 cbor2
 ecdsa
 attrs
+certvalidator
 
 # to build docs
 Sphinx>=3.3.1

--- a/tests/test_x509.py
+++ b/tests/test_x509.py
@@ -1,0 +1,22 @@
+from binascii import unhexlify
+from cose.headers import Algorithm
+from cose import headers, algorithms
+from cose.extensions.x509 import X5T
+
+
+def test_x5t():
+    data = b'doesntreallymatter'
+    tprint = unhexlify(b'55563f4a5a4f4acc536e150f87f5cb6a6a22f7fe7bd27846bf5564440a090f57')
+
+    head = X5T.from_certificate(algorithms.Sha256, data)
+    assert head.alg == algorithms.Sha256
+    assert head.thumbprint is not None
+
+    assert head.encode() == [
+        algorithms.Sha256,
+        tprint
+    ]
+    assert head.matches(data)
+
+    head2 = X5T.decode([-16, tprint])
+    assert head2 == head


### PR DESCRIPTION
This is not fully in the new cose class style, but does implement just-hash algorithms and x509 structures from the associated drafts to close #45.
There is also an implementation of a cert chain validation in 8c098f1 but it requires a new library dep so you may not want that one.