### PR TITLE
cose/keys: fix KpKid getter

### DIFF
--- a/cose/keys/cosekey.py
+++ b/cose/keys/cosekey.py
@@ -195,13 +195,13 @@ class CoseKey(MutableMapping, ABC):
     def kid(self) -> bytes:
         """ Returns the value of the :class:`~cose.keys.keyparam.KpKid` key parameter """
 
-        return self.store.get(KpKid, b'')
+        return self.store.get('KpKid', b'')
 
     @kid.setter
     def kid(self, kid: bytes) -> None:
         if type(kid) is not bytes:
             raise TypeError(f"kid must be of type 'bytes'")
-        self.store[KpKid] = kid
+        self.store['KpKid'] = kid
 
     @property
     def key_ops(self) -> List[Type['KEYOPS']]:


### PR DESCRIPTION
Unless I'm missing something it seems the getter is wrong since it's not passing the key correctly. I might be missing something since this pattern is heavily used throughout the file but without this fix I get the following:

```
Python 3.8.5 (default, Jan 27 2021, 15:41:15) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from cose.keys import OKPKey
>>> key = OKPKey.generate_key(crv='ED25519', optional_params={'KpKid': 4})
>>> key.kid
b''
>>> key.store['KpKid']
4
>>> 
```