### PR TITLE
Fix setup and test out-of-source in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,6 +44,7 @@ jobs:
     - name: Test with pytest
       run: |
         pip install .
+        pip show -f pycose
         mkdir tmp_for_test
         cp -r tests/ tmp_for_test/
         cd tmp_for_test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,6 +60,8 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
   test:
+    needs: build
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,55 @@ on:
 
 jobs:
   build:
+    runs-on: ubuntu-latest
 
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        pip install build
+
+    - name: Build package
+      run: |
+        python -m build
+    
+    - name: Upload package to artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: dist/
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    
+    - name: Install dependencies
+      run: |
+        pip install flake8
+    
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -22,29 +70,29 @@ jobs:
     - name: Checkout project
       uses: actions/checkout@v3
     
+    - name: Download package from artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+
+    - name: List all files
+      run: ls -R
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     
-    - name: Install dependencies
+    - name: Install test dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
-    
-    - name: Lint with flake8
+        pip install pytest
+
+    - name: Install package
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        pip install dist/*.whl
     
     - name: Test with pytest
       run: |
-        pip install .
-        pip show -f pycose
         mkdir tmp_for_test
         cp -r tests/ tmp_for_test/
         cd tmp_for_test

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -76,9 +76,7 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: dist
-
-    - name: List all files
-      run: ls -R
+        path: dist
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,29 +16,35 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout project
-      uses: actions/checkout@v2
-    - name: Checkout submodules
-      uses: snickerbockers/submodules-init@v4
+      uses: actions/checkout@v3
+    
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+    
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f dev-requirements.txt ]; then pip install -r dev-requirements.txt; fi
+    
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    
     - name: Test with pytest
       run: |
+        pip install .
+        mkdir tmp_for_test
+        cp -r tests/ tmp_for_test/
+        cd tmp_for_test
         pytest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 dist/
 docs/_build/*
 /.pytest_cache/
+build/
+tmp_for_test/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include dev-requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pycose
-version = 1.0.0
+version = 1.0.1
 author = Timothy Claeys
 author_email = timothy.claeys@gmail.com
 description = CBOR Object Signing and Encryption (COSE) implementation
@@ -39,4 +39,4 @@ install_requires = file: requirements.txt
 develop = file: dev-requirements.txt
 
 [options.packages.find]
-where = pycose
+include = pycose*

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,14 +23,13 @@ classifiers =
     Topic :: System :: Networking
     License :: OSI Approved :: BSD License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
 [options]
-python_requires= >=3.6
+python_requires= >=3.7
 zip_safe = False
 packages = find:
 install_requires = file: requirements.txt


### PR DESCRIPTION
Fixes #88. Closes #89.

EDIT: I changed the CI job to test against the installed package.

Other changes:
- Version bumped to 1.0.1 as the currently published package isn't useable and needs a hotfix release.
- Removed Python 3.6 from CI test matrix as `pip install` failed due to `setuptools` being too old. 3.6 is EOL and there is no need to test against that anymore. Soon, 3.11 can be added (not possible quite yet).