### PR TITLE
Avoid re-encoding of protected header

### DIFF
--- a/pycose/messages/enc0message.py
+++ b/pycose/messages/enc0message.py
@@ -48,11 +48,6 @@ class Enc0Message(enccommon.EncCommon):
         :returns: Returns a COSE Encrypt0 message object.
         """
 
-        if phdr is None:
-            phdr = {}
-        if uhdr is None:
-            uhdr = {}
-
         super().__init__(phdr, uhdr, payload, external_aad, key, *args, **kwargs)
 
     def encode(self, tag: bool = True, encrypt: bool = True, *args, **kwargs) -> CBOR:

--- a/pycose/messages/encmessage.py
+++ b/pycose/messages/encmessage.py
@@ -52,11 +52,6 @@ class EncMessage(enccommon.EncCommon):
         :param recipients: An optional list of :class:`~pycose.messages.recipient.CoseRecipient` objects.
         """
 
-        if phdr is None:
-            phdr = {}
-        if uhdr is None:
-            uhdr = {}
-
         super().__init__(phdr, uhdr, payload, external_aad, key, *args, **kwargs)
 
         self._recipients = []

--- a/pycose/messages/mac0message.py
+++ b/pycose/messages/mac0message.py
@@ -36,10 +36,6 @@ class Mac0Message(maccommon.MacCommon):
                  key: Optional['SK'] = None,
                  *args,
                  **kwargs):
-        if phdr is None:
-            phdr = {}
-        if uhdr is None:
-            uhdr = {}
 
         super().__init__(phdr, uhdr, payload, external_aad, key, *args, **kwargs)
 

--- a/pycose/messages/macmessage.py
+++ b/pycose/messages/macmessage.py
@@ -52,10 +52,6 @@ class MacMessage(maccommon.MacCommon):
                  recipients: Optional[List[CoseRecipient]] = None,
                  *args,
                  **kwargs):
-        if phdr is None:
-            phdr = {}
-        if uhdr is None:
-            uhdr = {}
 
         super().__init__(phdr, uhdr, payload, external_aad, key, *args, **kwargs)
 

--- a/pycose/messages/recipient.py
+++ b/pycose/messages/recipient.py
@@ -122,12 +122,7 @@ class CoseRecipient(CoseMessage, metaclass=abc.ABCMeta):
         :param recipients: An optional list of :class:`~pycose.messages.recipient.CoseRecipient` objects.
         """
 
-        if phdr is None:
-            phdr = {}
-        if uhdr is None:
-            uhdr = {}
-
-        super().__init__(phdr, uhdr, payload, external_aad, key, *args, *kwargs)
+        super().__init__(phdr, uhdr, payload, external_aad, key, *args, **kwargs)
 
         self._context = ''
         self._recipients = []

--- a/pycose/messages/sign1message.py
+++ b/pycose/messages/sign1message.py
@@ -33,10 +33,6 @@ class Sign1Message(SignCommon):
                  key: Optional[Union['EC2', 'OKP', 'RSA']] = None,
                  *args,
                  **kwargs):
-        if phdr is None:
-            phdr = {}
-        if uhdr is None:
-            uhdr = {}
 
         super().__init__(phdr, uhdr, payload, external_aad, key, *args, **kwargs)
 

--- a/pycose/messages/signer.py
+++ b/pycose/messages/signer.py
@@ -29,11 +29,6 @@ class CoseSignature(SignCommon):
                  *args,
                  **kwargs):
 
-        if phdr is None:
-            phdr = {}
-        if uhdr is None:
-            uhdr = {}
-
         super().__init__(phdr, uhdr, payload=signature, external_aad=external_aad, key=key, *args, **kwargs)
 
         self._parent = None

--- a/pycose/messages/signmessage.py
+++ b/pycose/messages/signmessage.py
@@ -46,11 +46,6 @@ class _SignMessage(CoseMessage, metaclass=abc.ABCMeta):
                  *args,
                  **kwargs):
 
-        if phdr is None:
-            phdr = {}
-        if uhdr is None:
-            uhdr = {}
-
         super(_SignMessage, self).__init__(phdr, uhdr, payload, external_aad=b'', key=None, *args, **kwargs)
 
         if signers is None:


### PR DESCRIPTION
This is a follow-up on https://github.com/TimothyClaeys/pycose/issues/82 to make modifying the unprotected header of an existing message more robust.

Currently, pycose re-encodes the protected header when decoding an existing message, changing the unprotected header, and re-encoding it (using `sign=False` to avoid re-signing).

If the original COSE message was created by pycose then the same CBOR encoder (cbor2) is used when re-encoding the message, which typically means that the protected header is re-encoded bit-for-bit the same. However, relying on this is brittle, especially since COSE does not enforce any deterministic encoding for the protected header.

This PR preserves the encoded protected header and avoids re-encoding it.