### PR TITLE
Upload package to PyPI from CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,9 +5,7 @@ name: Python package
 
 on:
   push:
-    branches: [ "master", "develop" ]
   pull_request:
-    branches: [ "master", "develop" ]
 
 jobs:
   build:
@@ -97,3 +95,30 @@ jobs:
         cp -r tests/ tmp_for_test/
         cd tmp_for_test
         pytest
+
+  release:
+    needs: [lint, test]
+
+    runs-on: ubuntu-latest
+
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+    - name: Download package from artifacts
+      uses: actions/download-artifact@v3
+      with:
+        name: dist
+        path: dist
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        pip install twine
+    
+    - name: Upload package to PyPI
+      run: |
+        twine upload -u __token__ -p ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*


### PR DESCRIPTION
This PR extends the CI such that when a git tag is pushed, the built and tested package is automatically pushed to PyPI using twine.

NOTE: For this to work, a GitHub Actions secret has to be created in the repository settings called `PYPI_TOKEN` with the value set to an API token from PyPI.