### PR TITLE
Make package compliant with PEP-561

### DIFF
--- a/pycose/py.typed
+++ b/pycose/py.typed
@@ -1,0 +1,1 @@
+# Present to statisfy https://peps.python.org/pep-0561/#packaging-type-information

--- a/pycose/py.typed
+++ b/pycose/py.typed
@@ -1,1 +1,1 @@
-# Marker file for PEP 561.  The mypy package uses inline types.
+# Marker file for PEP 561. The pycose package uses inline types.

--- a/pycose/py.typed
+++ b/pycose/py.typed
@@ -1,1 +1,1 @@
-# Present to satisfy https://peps.python.org/pep-0561/#packaging-type-information
+# Marker file for PEP 561.  The mypy package uses inline types.

--- a/pycose/py.typed
+++ b/pycose/py.typed
@@ -1,1 +1,1 @@
-# Present to statisfy https://peps.python.org/pep-0561/#packaging-type-information
+# Present to satisfy https://peps.python.org/pep-0561/#packaging-type-information

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,3 +39,6 @@ develop = file: dev-requirements.txt
 
 [options.packages.find]
 include = pycose*
+
+[options.package_data]
+pycose = py.typed


### PR DESCRIPTION
A minor change to make it possible for projects depending on pycose to use the (very useful!) type annotations it includes.

This is, as far as I can tell, the simplest way to do that by complying with https://peps.python.org/pep-0561/#packaging-type-information, but if I've missed something and there's a more up-to-date method, I'll be happily corrected.