### PR TITLE
Fix inconsistencies in the type annotations of the curve module.

### DIFF
--- a/pycose/algorithms.py
+++ b/pycose/algorithms.py
@@ -293,8 +293,8 @@ class _EcdhHkdf(CoseAlgorithm, ABC):
         x_value = int(hexlify(public_key.x), 16)
         y_value = int(hexlify(public_key.y), 16)
 
-        d = ec.derive_private_key(d_value, curve.curve_obj(), backend=default_backend())
-        p = ec.EllipticCurvePublicNumbers(x_value, y_value, curve.curve_obj())
+        d = ec.derive_private_key(d_value, curve.curve_obj, backend=default_backend())
+        p = ec.EllipticCurvePublicNumbers(x_value, y_value, curve.curve_obj)
         p = p.public_key(backend=default_backend())
 
         shared_key = d.exchange(ECDH(), p)

--- a/pycose/keys/curves.py
+++ b/pycose/keys/curves.py
@@ -1,17 +1,24 @@
 from abc import ABC, abstractmethod
-from typing import Union
+from typing import Union, Type, ClassVar
 
-from cryptography.hazmat.primitives.asymmetric import ed25519, ed448, x25519, x448
-from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve, SECP256K1, SECP256R1, SECP384R1, SECP521R1
+from cryptography.hazmat.primitives.asymmetric import ed25519, ed448, x25519, x448, ec
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 
 from pycose.keys.keytype import KtyEC2, KtyOKP
 from pycose.utils import _CoseAttribute
 
-EdwardsCurve = Union[ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey, x25519.X25519PrivateKey, x448.X448PrivateKey]
+EdwardsPrivateKey = Union[ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey, x25519.X25519PrivateKey, x448.X448PrivateKey]
 
 
 class CoseCurve(_CoseAttribute, ABC):
-    """ Base class for all COSE curves. """
+    """
+    Base class for all COSE curves
+
+    Attributes:
+        curve_obj: A curve object from the cryptography package.
+        key_type: The key type associated with the curve.
+        size: The size of the coordinates over the curve.
+    """
 
     _registered_curves = {}
 
@@ -19,29 +26,9 @@ class CoseCurve(_CoseAttribute, ABC):
     def get_registered_classes(cls):
         return cls._registered_curves
 
-    @property
-    @abstractmethod
-    def curve_obj(self) -> Union[EllipticCurve, 'EdwardsCurve']:
-        """
-        Returns a curve object from the cryptography package
-        """
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
-    def key_type(self) -> Union['KtyEC2', 'KtyOKP']:
-        """
-        Returns the key type associated with the curve
-        """
-        raise NotImplementedError()
-
-    @property
-    @abstractmethod
-    def size(self) -> int:
-        """
-        Returns the size of the coordinates over the curve
-        """
-        raise NotImplementedError()
+    curve_obj: ClassVar[Union[EllipticCurve, Type[EdwardsPrivateKey], None]]
+    key_type: ClassVar[Union[Type[KtyEC2], Type[KtyOKP], None]]
+    size: ClassVar[int]
 
 
 ##################################################
@@ -92,7 +79,7 @@ class P256(CoseCurve):
 
     identifier = 1
     fullname = "P_256"
-    curve_obj = SECP256R1
+    curve_obj = ec.SECP256R1()
     key_type = KtyEC2
     size = 32
 
@@ -116,7 +103,7 @@ class P384(CoseCurve):
 
     identifier = 2
     fullname = "P_384"
-    curve_obj = SECP384R1
+    curve_obj = ec.SECP384R1()
     key_type = KtyEC2
     size = 48
 
@@ -140,7 +127,7 @@ class P521(CoseCurve):
 
     identifier = 3
     fullname = "P_521"
-    curve_obj = SECP521R1
+    curve_obj = ec.SECP521R1()
     key_type = KtyEC2
     size = 66
 
@@ -260,7 +247,7 @@ class SECP256K1(CoseCurve):
 
     identifier = 8
     fullname = "SECP256K1"
-    curve_obj = SECP256K1
+    curve_obj = ec.SECP256K1()
     key_type = KtyEC2
     size = 32
 

--- a/pycose/keys/ec2.py
+++ b/pycose/keys/ec2.py
@@ -95,7 +95,7 @@ class EC2Key(CoseKey):
 
         if d:
             public_nums = ec.derive_private_key(int.from_bytes(d, byteorder="big"),
-                                                curve=self.crv.curve_obj(),
+                                                curve=self.crv.curve_obj,
                                                 backend=default_backend()).public_key().public_numbers()
             if x:
                 assert x == public_nums.x.to_bytes(self.crv.size, 'big')
@@ -109,7 +109,7 @@ class EC2Key(CoseKey):
 
         if x and not y:
             # try to derive y from x
-            key = ec.EllipticCurvePublicKey.from_encoded_point(self.crv.curve_obj(),
+            key = ec.EllipticCurvePublicKey.from_encoded_point(self.crv.curve_obj,
                                                                # don't care which of the two possible Y values we get
                                                                b'\x03' +
                                                                x  # or [::-1]?


### PR DESCRIPTION
- The curve_obj attribute for elliptic curves was set to reference the curve's *type*, rather than an instance of the type. This contradicted both the type annotation, and the recommended usage in the cryptography package, whose functions always expect an instance. All the definitions of that attribute now create a cryptography curve instance.

- There was a similar discrepancy for OKP curves, which used a basic Ed25519PrivateKey (or similar) annotation, but hold references to the class, rather than a specific instance. In this case, the type annotation was modified using the Type constructor to accurately reflect this.

- All curve attributes were marked as abstract properties, which makes them attributes of *instances* of CoseCurve, even though throughout the codebase they are use as class attributes throughout the codebase. This is fixed by using the ClassVar type constructor on the attributes. Unfortunately there seems to be no reliably supported way of combining @classmethod and @property.

- There was some accidental shadowing, by defining a curve class with the same name as the imported type from the cryptography package. We now always refer to the imported curves using ec. to avoid ambiguities.