### PR TITLE
Revert "Remove `attrs` package dependency"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cryptography
 cbor2
 ecdsa
+attrs
 certvalidator


### PR DESCRIPTION
Reverts TimothyClaeys/pycose#104

It turns out this package is used after all, in pycose/messages/context.py using `import attr`. I didn't notice this earlier as I was looking for `attrs` (plural). Apparently the [attrs](https://www.attrs.org/en/stable/api.html) package contains both `attrs` and `attr` top-level packages.

This was passing CI because the package was pulled in via a test dependency. We should extend CI to do an import test without any further dependencies to catch those issues.