### PR TITLE
Add `from_pem_private_key`/`from_pem_public_key` methods

### DIFF
--- a/docs/pycose/keys/cosekey.rst
+++ b/docs/pycose/keys/cosekey.rst
@@ -35,6 +35,27 @@ The :class:`~pycose.keys.cosekey.CoseKey` class can be used to decode serialized
     >>> cosekey.d
     b'\x8fx\x1a\tSr\xf8[m\x9fa\t\xaeB&\x11sM}\xbf\xa0\x06\x9a-\xf2\x93[\xb2\xe0S\xbf5'
 
+Alternatively, :class:`~pycose.keys.cosekey.CoseKey` objects can be initialized from key objects of the `pyca/cryptography`_ package:
+
+.. _`pyca/cryptography`:  https://cryptography.io/
+
+.. doctest::
+    :pyversion: >= 3.6
+
+    >>> from pycose.keys import CoseKey
+    >>> from cryptography.hazmat.primitives.serialization import load_pem_public_key
+
+    >>> encoded_key = '-----BEGIN PUBLIC KEY-----\n' \
+    ...               'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyIBhex88X7Yrh5Q4hbmsUYpcVWNj\n' \
+    ...               'mx1oE7TPomgpZJcQeNC3bX++GPsIWewWEGGFJKwHtRyfrL61DTTym3Rp8A==\n' \
+    ...               '-----END PUBLIC KEY-----\n'
+    >>> key = load_pem_public_key(encoded_key.encode("ascii"))
+    
+    >>> cosekey = CoseKey.from_cryptography_key(key)
+    >>> cosekey
+    <COSE_Key(EC2Key): {'EC2KpY': "b'\\x10x\\xd0\\xb7m' ... (32 B)", 'EC2KpX': "b'\\xc8\\x80a{\\x1f' ... (32 B)", 'EC2KpCurve': 'P256', 'KpKty': 'KtyEC2'}>
+
+
 Overview
 --------
 

--- a/docs/pycose/keys/cosekey.rst
+++ b/docs/pycose/keys/cosekey.rst
@@ -35,7 +35,7 @@ The :class:`~pycose.keys.cosekey.CoseKey` class can be used to decode serialized
     >>> cosekey.d
     b'\x8fx\x1a\tSr\xf8[m\x9fa\t\xaeB&\x11sM}\xbf\xa0\x06\x9a-\xf2\x93[\xb2\xe0S\xbf5'
 
-Alternatively, :class:`~pycose.keys.cosekey.CoseKey` objects can be initialized from key objects of the `pyca/cryptography`_ package:
+Alternatively, :class:`~pycose.keys.cosekey.CoseKey` objects can be initialized from PEM-encoded keys:
 
 .. _`pyca/cryptography`:  https://cryptography.io/
 
@@ -43,15 +43,13 @@ Alternatively, :class:`~pycose.keys.cosekey.CoseKey` objects can be initialized 
     :pyversion: >= 3.6
 
     >>> from pycose.keys import CoseKey
-    >>> from cryptography.hazmat.primitives.serialization import load_pem_public_key
 
-    >>> encoded_key = '-----BEGIN PUBLIC KEY-----\n' \
-    ...               'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyIBhex88X7Yrh5Q4hbmsUYpcVWNj\n' \
-    ...               'mx1oE7TPomgpZJcQeNC3bX++GPsIWewWEGGFJKwHtRyfrL61DTTym3Rp8A==\n' \
-    ...               '-----END PUBLIC KEY-----\n'
-    >>> key = load_pem_public_key(encoded_key.encode("ascii"))
-    
-    >>> cosekey = CoseKey.from_cryptography_key(key)
+    >>> pem = '-----BEGIN PUBLIC KEY-----\n' \
+    ...       'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyIBhex88X7Yrh5Q4hbmsUYpcVWNj\n' \
+    ...       'mx1oE7TPomgpZJcQeNC3bX++GPsIWewWEGGFJKwHtRyfrL61DTTym3Rp8A==\n' \
+    ...       '-----END PUBLIC KEY-----\n'
+
+    >>> cosekey = CoseKey.from_pem_public_key(pem)
     >>> cosekey
     <COSE_Key(EC2Key): {'EC2KpY': "b'\\x10x\\xd0\\xb7m' ... (32 B)", 'EC2KpX': "b'\\xc8\\x80a{\\x1f' ... (32 B)", 'EC2KpCurve': 'P256', 'KpKty': 'KtyEC2'}>
 

--- a/pycose/keys/cosekey.py
+++ b/pycose/keys/cosekey.py
@@ -94,6 +94,17 @@ class CoseKey(MutableMapping, ABC):
 
         return key_obj
 
+    @classmethod
+    def from_cryptography_key(
+        cls,
+        ext_key,
+        optional_params: Optional[dict] = None
+    ) -> 'CK':
+        for key_type in cls._key_types.values():
+            if key_type._supports_cryptography_key_type(ext_key):
+                return key_type.from_cryptography_key(ext_key, optional_params)
+        raise CoseIllegalKeyType(f"Unsupported key type: {type(ext_key)}")
+
     @staticmethod
     def base64decode(to_decode: str) -> bytes:
         """

--- a/pycose/keys/cosekey.py
+++ b/pycose/keys/cosekey.py
@@ -100,6 +100,14 @@ class CoseKey(MutableMapping, ABC):
         ext_key,
         optional_params: Optional[dict] = None
     ) -> 'CK':
+        """
+        Initialize a COSE key from a cryptography key.
+
+        :param ext_key: A cryptography key.
+        :param optional_params: Optional parameters to add to the key.
+        :return: An initialized COSE Key object.
+        """
+
         for key_type in cls._key_types.values():
             if key_type._supports_cryptography_key_type(ext_key):
                 return key_type.from_cryptography_key(ext_key, optional_params)

--- a/pycose/keys/cosekey.py
+++ b/pycose/keys/cosekey.py
@@ -99,7 +99,7 @@ class CoseKey(MutableMapping, ABC):
         cls,
         ext_key,
         optional_params: Optional[dict] = None
-    ) -> 'CK':
+    ) -> "CoseKey":
         """
         Initialize a COSE key from a cryptography key.
 

--- a/pycose/keys/ec2.py
+++ b/pycose/keys/ec2.py
@@ -56,7 +56,7 @@ class EC2Key(CoseKey):
         if not cls._supports_cryptography_key_type(ext_key):
             raise CoseIllegalKeyType(f"Unsupported key type: {type(ext_key)}")
 
-        if hasattr(ext_key, "private_numbers"):
+        if isinstance(ext_key, ec.EllipticCurvePrivateKey):
             priv_nums = ext_key.private_numbers()
             pub_nums = priv_nums.public_numbers
         else:

--- a/pycose/keys/ec2.py
+++ b/pycose/keys/ec2.py
@@ -9,10 +9,10 @@ from pycose.keys.cosekey import CoseKey
 from pycose.keys.keyops import SignOp, VerifyOp, DeriveKeyOp, DeriveBitsOp
 from pycose.keys.keyparam import EC2KeyParam, EC2KpCurve, EC2KpX, EC2KpY, EC2KpD, KpKty, KeyParam
 from pycose.keys.keytype import KtyEC2
+from pycose.keys.curves import CoseCurve
 
 if TYPE_CHECKING:
     from pycose.keys.keyops import KEYOPS
-    from pycose.keys.curves import CoseCurve
 
 
 @CoseKey.record_kty(KtyEC2)
@@ -41,6 +41,60 @@ class EC2Key(CoseKey):
         CoseKey._remove_from_dict(_optional_params, EC2KpCurve)
 
         return cls(crv=curve, x=x, y=y, d=d, optional_params=_optional_params, allow_unknown_key_attrs=True)
+
+    @classmethod
+    def from_cryptography_key(
+        cls,
+        ext_key: Union[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey],
+        optional_params: Optional[dict] = None
+    ) -> 'EC2Key':
+        """
+        Returns an initialized COSE Key object of type EC2Key.
+        :param ext_key: Python cryptography key.
+        :return: an initialized EC key
+        """
+        if not cls._supports_cryptography_key_type(ext_key):
+            raise CoseIllegalKeyType(f"Unsupported key type: {type(ext_key)}")
+
+        if hasattr(ext_key, "private_numbers"):
+            priv_nums = ext_key.private_numbers()
+            pub_nums = priv_nums.public_numbers
+        else:
+            priv_nums = None
+            pub_nums = ext_key.public_numbers()
+
+        curves = {
+            type(curve_cls.curve_obj): curve_cls
+            for curve_cls in CoseCurve.get_registered_classes().values()
+            if curve_cls.key_type == KtyEC2
+        }
+
+        if type(pub_nums.curve) not in curves:
+            raise CoseUnsupportedCurve(f"Unsupported EC Curve: {type(pub_nums.curve)}")
+        curve = curves[type(pub_nums.curve)]
+
+        cose_key = {}
+        if pub_nums:
+            cose_key.update(
+                {
+                    EC2KpCurve: curve,
+                    EC2KpX: pub_nums.x.to_bytes(curve.size, "big"),
+                    EC2KpY: pub_nums.y.to_bytes(curve.size, "big"),
+                }
+            )
+        if priv_nums:
+            cose_key.update(
+                {
+                    EC2KpD: priv_nums.private_value.to_bytes(curve.size, "big"),
+                }
+            )
+        if optional_params:
+            cose_key.update(optional_params)
+        return cls.from_dict(cose_key)
+
+    @staticmethod
+    def _supports_cryptography_key_type(ext_key) -> bool:
+        return isinstance(ext_key, (ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey))
 
     @staticmethod
     def _key_transform(key: Union[Type['EC2KeyParam'], Type['KeyParam'], str, int], allow_unknown_attrs: bool = False):
@@ -220,16 +274,9 @@ class EC2Key(CoseKey):
         if crv.key_type != KtyEC2:
             raise CoseUnsupportedCurve(f'Unsupported COSE curve: {crv}')
 
-        private_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
-        d_value = private_key.private_numbers().private_value
-        x_coor = private_key.public_key().public_numbers().x
-        y_coor = private_key.public_key().public_numbers().y
-
-        return EC2Key(crv=crv,
-                      d=d_value.to_bytes(crv.size, "big"),
-                      x=x_coor.to_bytes(crv.size, "big"),
-                      y=y_coor.to_bytes(crv.size, "big"),
-                      optional_params=optional_params)
+        ext_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
+        
+        return cls.from_cryptography_key(ext_key, optional_params)
 
     def __delitem__(self, key):
         if self._key_transform(key) != KpKty and self._key_transform(key) != EC2KpCurve:

--- a/pycose/keys/ec2.py
+++ b/pycose/keys/ec2.py
@@ -42,9 +42,8 @@ class EC2Key(CoseKey):
 
         return cls(crv=curve, x=x, y=y, d=d, optional_params=_optional_params, allow_unknown_key_attrs=True)
 
-    @classmethod
-    def from_cryptography_key(
-        cls,
+    @staticmethod
+    def _from_cryptography_key(
         ext_key: Union[ec.EllipticCurvePrivateKey, ec.EllipticCurvePublicKey],
         optional_params: Optional[dict] = None
     ) -> 'EC2Key':
@@ -53,7 +52,7 @@ class EC2Key(CoseKey):
         :param ext_key: Python cryptography key.
         :return: an initialized EC key
         """
-        if not cls._supports_cryptography_key_type(ext_key):
+        if not EC2Key._supports_cryptography_key_type(ext_key):
             raise CoseIllegalKeyType(f"Unsupported key type: {type(ext_key)}")
 
         if isinstance(ext_key, ec.EllipticCurvePrivateKey):
@@ -90,7 +89,7 @@ class EC2Key(CoseKey):
             )
         if optional_params:
             cose_key.update(optional_params)
-        return cls.from_dict(cose_key)
+        return EC2Key.from_dict(cose_key)
 
     @staticmethod
     def _supports_cryptography_key_type(ext_key) -> bool:
@@ -276,7 +275,7 @@ class EC2Key(CoseKey):
 
         ext_key = ec.generate_private_key(crv.curve_obj, backend=default_backend())
         
-        return cls.from_cryptography_key(ext_key, optional_params)
+        return cls._from_cryptography_key(ext_key, optional_params)
 
     def __delitem__(self, key):
         if self._key_transform(key) != KpKty and self._key_transform(key) != EC2KpCurve:

--- a/pycose/keys/okp.py
+++ b/pycose/keys/okp.py
@@ -88,16 +88,14 @@ class OKPKey(CoseKey):
     @staticmethod
     def _curve_from_cryptography_key(ext_key) -> Type[CoseCurve]:
         if isinstance(ext_key, (ed25519.Ed25519PrivateKey, ed25519.Ed25519PublicKey)):
-            curve = curves.Ed25519
-        elif isinstance(ext_key, (ed448.Ed448PrivateKey, ed448.Ed448PublicKey)):
-            curve = curves.Ed448
-        elif isinstance(ext_key, (x25519.X25519PrivateKey, x25519.X25519PublicKey)):
-            curve = curves.X25519
-        elif isinstance(ext_key, (x448.X448PrivateKey, x448.X448PublicKey)):
-            curve = curves.X448
-        else:
-            raise CoseIllegalKeyType(f"Unsupported key type: {type(ext_key)}")
-        return curve
+            return curves.Ed25519
+        if isinstance(ext_key, (ed448.Ed448PrivateKey, ed448.Ed448PublicKey)):
+            return curves.Ed448
+        if isinstance(ext_key, (x25519.X25519PrivateKey, x25519.X25519PublicKey)):
+            return curves.X25519
+        if isinstance(ext_key, (x448.X448PrivateKey, x448.X448PublicKey)):
+            return curves.X448
+        raise CoseIllegalKeyType(f"Unsupported key type: {type(ext_key)}")
 
     @classmethod
     def _supports_cryptography_key_type(cls, ext_key) -> bool:

--- a/pycose/keys/okp.py
+++ b/pycose/keys/okp.py
@@ -75,19 +75,12 @@ class OKPKey(CoseKey):
             priv_bytes = None
             pub_bytes = ext_key.public_bytes(encoding=Encoding.Raw, format=PublicFormat.Raw)
 
-        cose_key = {}
-        cose_key.update(
-            {
-                OKPKpCurve: curve,
-                OKPKpX: pub_bytes,
-            }
-        )
+        cose_key = {
+            OKPKpCurve: curve,
+            OKPKpX: pub_bytes,
+        }
         if priv_bytes:
-            cose_key.update(
-                {
-                    OKPKpD: priv_bytes,
-                }
-            )
+            cose_key[OKPKpD] = priv_bytes
         if optional_params:
             cose_key.update(optional_params)
         return OKPKey.from_dict(cose_key)

--- a/pycose/keys/okp.py
+++ b/pycose/keys/okp.py
@@ -43,9 +43,8 @@ class OKPKey(CoseKey):
 
         return cls(crv=curve, x=x, d=d, optional_params=_optional_params, allow_unknown_key_attrs=True)
 
-    @classmethod
-    def from_cryptography_key(
-        cls,
+    @staticmethod
+    def _from_cryptography_key(
         ext_key: Union[
             ed25519.Ed25519PrivateKey, ed25519.Ed25519PublicKey,
             ed448.Ed448PrivateKey, ed448.Ed448PublicKey,
@@ -60,7 +59,7 @@ class OKPKey(CoseKey):
         :return: an initialized OKP key
         """
 
-        curve = cls._curve_from_cryptography_key(ext_key)
+        curve = OKPKey._curve_from_cryptography_key(ext_key)
 
         if hasattr(ext_key, 'private_bytes'):
             priv_bytes = ext_key.private_bytes(
@@ -241,7 +240,7 @@ class OKPKey(CoseKey):
 
         ext_key = crv.curve_obj.generate()
 
-        return cls.from_cryptography_key(ext_key, optional_params)
+        return cls._from_cryptography_key(ext_key, optional_params)
 
     def __delitem__(self, key: Union['KeyParam', str, int]):
         if self._key_transform(key) != KpKty and self._key_transform(key) != OKPKpCurve:

--- a/pycose/keys/rsa.py
+++ b/pycose/keys/rsa.py
@@ -88,19 +88,17 @@ class RSAKey(CoseKey):
         if not cls._supports_cryptography_key_type(ext_key):
             raise CoseIllegalKeyType(f"Unsupported key type: {type(ext_key)}")
 
-        if hasattr(ext_key, 'private_numbers'):
+        if isinstance(ext_key, rsa.RSAPrivateKey):
             priv_nums = ext_key.private_numbers()
             pub_nums = priv_nums.public_numbers
         else:
             priv_nums = None
             pub_nums = ext_key.public_numbers()
 
-        cose_key = {}
-        if pub_nums:
-            cose_key.update({
-                RSAKpE: to_bstr(pub_nums.e),
-                RSAKpN: to_bstr(pub_nums.n),
-            })
+        cose_key = {
+            RSAKpE: to_bstr(pub_nums.e),
+            RSAKpN: to_bstr(pub_nums.n),
+        }
         if priv_nums:
             cose_key.update({
                 RSAKpD: to_bstr(priv_nums.d),

--- a/pycose/keys/rsa.py
+++ b/pycose/keys/rsa.py
@@ -74,9 +74,8 @@ class RSAKey(CoseKey):
                    optional_params=_optional_params,
                    allow_unknown_key_attrs=True)
 
-    @classmethod
-    def from_cryptography_key(
-        cls,
+    @staticmethod
+    def _from_cryptography_key(
         ext_key: Union[rsa.RSAPrivateKey, rsa.RSAPublicKey],
         optional_params: Optional[dict] = None
     ) -> 'RSAKey':
@@ -85,7 +84,7 @@ class RSAKey(CoseKey):
         :param ext_key: Python cryptography key.
         :return: an initialized RSA key
         """
-        if not cls._supports_cryptography_key_type(ext_key):
+        if not RSAKey._supports_cryptography_key_type(ext_key):
             raise CoseIllegalKeyType(f"Unsupported key type: {type(ext_key)}")
 
         if isinstance(ext_key, rsa.RSAPrivateKey):
@@ -110,7 +109,7 @@ class RSAKey(CoseKey):
             })
         if optional_params:
             cose_key.update(optional_params)
-        return cls.from_dict(cose_key)
+        return RSAKey.from_dict(cose_key)
 
     @staticmethod
     def _supports_cryptography_key_type(ext_key) -> bool:
@@ -313,7 +312,7 @@ class RSAKey(CoseKey):
 
         ext_key = rsa.generate_private_key(public_exponent=65537, key_size=key_bits, backend=default_backend())
 
-        return cls.from_cryptography_key(ext_key, optional_params)
+        return cls._from_cryptography_key(ext_key, optional_params)
 
     def __repr__(self):
         hdr = f'<COSE_Key(RSAKey): {self._key_repr()}>'

--- a/pycose/keys/symmetric.py
+++ b/pycose/keys/symmetric.py
@@ -34,6 +34,10 @@ class SymmetricKey(CoseKey):
         return cls(k=k, optional_params=_optional_params, allow_unknown_key_attrs=True)
 
     @staticmethod
+    def _supports_cryptography_key_type(ext_key) -> bool:
+        return False
+
+    @staticmethod
     def _key_transform(key: Union[Type['SymmetricKeyParam'], Type['KeyParam'], str, int],
                        allow_unknown_attrs: bool = False):
         return SymmetricKeyParam.from_id(key, allow_unknown_attrs)

--- a/tests/test_ec2_keys.py
+++ b/tests/test_ec2_keys.py
@@ -2,6 +2,8 @@ from binascii import unhexlify
 
 import pytest
 
+from cryptography.hazmat.primitives.asymmetric import ec
+
 from pycose.algorithms import Es256
 from pycose.keys.curves import P521, P384, P256
 from pycose.exceptions import CoseInvalidKey, CoseIllegalKeyType, CoseException, CoseUnsupportedCurve
@@ -72,6 +74,23 @@ def test_ec2_private_key_from_dicts(kty_attr, kty_value, crv_attr, crv_value, d_
 def test_ec2_public_keys_from_dicts(kty_attr, kty_value, crv_attr, crv_value, x_attr, x_value, y_attr, y_value):
     dct = {kty_attr: kty_value, crv_attr: crv_value, x_attr: x_value, y_attr: y_value}
     cose_key = CoseKey.from_dict(dct)
+    assert _is_valid_ec2_key(cose_key)
+
+
+def test_ec2_private_key_from_cryptography():
+    from_bstr = lambda enc: int.from_bytes(enc, byteorder='big')
+    pub_nums = ec.EllipticCurvePublicNumbers(from_bstr(p256_x), from_bstr(p256_y), ec.SECP256R1())
+    priv_nums = ec.EllipticCurvePrivateNumbers(from_bstr(p256_d), pub_nums)
+    private_key = priv_nums.private_key()
+    cose_key = CoseKey.from_cryptography_key(private_key)
+    assert _is_valid_ec2_key(cose_key)
+
+
+def test_ec2_public_key_from_cryptography():
+    from_bstr = lambda enc: int.from_bytes(enc, byteorder='big')
+    pub_nums = ec.EllipticCurvePublicNumbers(from_bstr(p256_x), from_bstr(p256_y), ec.SECP256R1())
+    public_key = pub_nums.public_key()
+    cose_key = CoseKey.from_cryptography_key(public_key)
     assert _is_valid_ec2_key(cose_key)
 
 

--- a/tests/test_ec2_keys.py
+++ b/tests/test_ec2_keys.py
@@ -3,6 +3,7 @@ from binascii import unhexlify
 import pytest
 
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
 
 from pycose.algorithms import Es256
 from pycose.keys.curves import P521, P384, P256
@@ -77,20 +78,22 @@ def test_ec2_public_keys_from_dicts(kty_attr, kty_value, crv_attr, crv_value, x_
     assert _is_valid_ec2_key(cose_key)
 
 
-def test_ec2_private_key_from_cryptography():
+def test_ec2_private_key_from_pem():
     from_bstr = lambda enc: int.from_bytes(enc, byteorder='big')
     pub_nums = ec.EllipticCurvePublicNumbers(from_bstr(p256_x), from_bstr(p256_y), ec.SECP256R1())
     priv_nums = ec.EllipticCurvePrivateNumbers(from_bstr(p256_d), pub_nums)
     private_key = priv_nums.private_key()
-    cose_key = CoseKey.from_cryptography_key(private_key)
+    pem = private_key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+    cose_key = CoseKey.from_pem_private_key(pem)
     assert _is_valid_ec2_key(cose_key)
 
 
-def test_ec2_public_key_from_cryptography():
+def test_ec2_public_key_from_pem():
     from_bstr = lambda enc: int.from_bytes(enc, byteorder='big')
     pub_nums = ec.EllipticCurvePublicNumbers(from_bstr(p256_x), from_bstr(p256_y), ec.SECP256R1())
     public_key = pub_nums.public_key()
-    cose_key = CoseKey.from_cryptography_key(public_key)
+    pem = public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode()
+    cose_key = CoseKey.from_pem_public_key(pem)
     assert _is_valid_ec2_key(cose_key)
 
 

--- a/tests/test_okp_keys.py
+++ b/tests/test_okp_keys.py
@@ -4,6 +4,7 @@ from binascii import unhexlify
 import pytest
 
 from cryptography.hazmat.primitives.asymmetric import ed25519, ed448, x25519, x448
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
 
 from pycose.algorithms import EdDSA
 from pycose.exceptions import CoseInvalidKey, CoseIllegalKeyType, CoseUnsupportedCurve, CoseIllegalKeyOps
@@ -68,19 +69,21 @@ def test_okp_public_keys_from_dicts(kty_attr, kty_value, crv_attr, crv_value, x_
 @pytest.mark.parametrize('key_class', [
     ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey,
     x25519.X25519PrivateKey, x448.X448PrivateKey])
-def test_okp_private_key_from_cryptography(key_class):
+def test_okp_private_key_from_pem(key_class):
     private_key = key_class.generate()
-    cose_key = CoseKey.from_cryptography_key(private_key)
+    pem = private_key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+    cose_key = CoseKey.from_pem_private_key(pem)
     assert _is_valid_okp_key(cose_key)
 
 
 @pytest.mark.parametrize('key_class', [
     ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey,
     x25519.X25519PrivateKey, x448.X448PrivateKey])
-def test_okp_public_key_from_cryptography(key_class):
+def test_okp_public_key_from_pem(key_class):
     private_key = key_class.generate()
     public_key = private_key.public_key()
-    cose_key = CoseKey.from_cryptography_key(public_key)
+    pem = public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode()
+    cose_key = CoseKey.from_pem_public_key(pem)
     assert _is_valid_okp_key(cose_key)
 
 

--- a/tests/test_okp_keys.py
+++ b/tests/test_okp_keys.py
@@ -3,6 +3,8 @@ from binascii import unhexlify
 
 import pytest
 
+from cryptography.hazmat.primitives.asymmetric import ed25519, ed448, x25519, x448
+
 from pycose.algorithms import EdDSA
 from pycose.exceptions import CoseInvalidKey, CoseIllegalKeyType, CoseUnsupportedCurve, CoseIllegalKeyOps
 from pycose.keys import OKPKey, CoseKey
@@ -60,6 +62,25 @@ def test_okp_public_keys_from_dicts(kty_attr, kty_value, crv_attr, crv_value, x_
 
     d = {kty_attr: kty_value, crv_attr: crv_value, x_attr: x_value}
     cose_key = CoseKey.from_dict(d)
+    assert _is_valid_okp_key(cose_key)
+
+
+@pytest.mark.parametrize('key_class', [
+    ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey,
+    x25519.X25519PrivateKey, x448.X448PrivateKey])
+def test_okp_private_key_from_cryptography(key_class):
+    private_key = key_class.generate()
+    cose_key = CoseKey.from_cryptography_key(private_key)
+    assert _is_valid_okp_key(cose_key)
+
+
+@pytest.mark.parametrize('key_class', [
+    ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey,
+    x25519.X25519PrivateKey, x448.X448PrivateKey])
+def test_okp_public_key_from_cryptography(key_class):
+    private_key = key_class.generate()
+    public_key = private_key.public_key()
+    cose_key = CoseKey.from_cryptography_key(public_key)
     assert _is_valid_okp_key(cose_key)
 
 

--- a/tests/test_rsa_keys.py
+++ b/tests/test_rsa_keys.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
 
 from pycose.exceptions import CoseIllegalKeyType
 from pycose.keys import RSAKey, CoseKey
@@ -51,14 +52,16 @@ def test_dict_operations_on_rsa_key():
     assert 'KEY_OPS' not in key
 
 
-def test_rsa_private_key_from_cryptography():
+def test_rsa_private_key_from_pem():
     private_key = rsa.generate_private_key(65537, 2048)
-    cose_key = CoseKey.from_cryptography_key(private_key)
+    pem = private_key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+    cose_key = CoseKey.from_pem_private_key(pem)
     assert isinstance(cose_key, RSAKey)
 
 
-def test_rsa_public_key_from_cryptography():
+def test_rsa_public_key_from_pem():
     private_key = rsa.generate_private_key(65537, 2048)
     public_key = private_key.public_key()
-    cose_key = CoseKey.from_cryptography_key(public_key)
+    pem = public_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo).decode()
+    cose_key = CoseKey.from_pem_public_key(pem)
     assert isinstance(cose_key, RSAKey)

--- a/tests/test_rsa_keys.py
+++ b/tests/test_rsa_keys.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+from cryptography.hazmat.primitives.asymmetric import rsa
+
 from pycose.exceptions import CoseIllegalKeyType
 from pycose.keys import RSAKey, CoseKey
 from pycose.keys.keyops import SignOp
@@ -47,3 +49,16 @@ def test_dict_operations_on_rsa_key():
     assert 'subject_name' in key
 
     assert 'KEY_OPS' not in key
+
+
+def test_rsa_private_key_from_cryptography():
+    private_key = rsa.generate_private_key(65537, 2048)
+    cose_key = CoseKey.from_cryptography_key(private_key)
+    assert isinstance(cose_key, RSAKey)
+
+
+def test_rsa_public_key_from_cryptography():
+    private_key = rsa.generate_private_key(65537, 2048)
+    public_key = private_key.public_key()
+    cose_key = CoseKey.from_cryptography_key(public_key)
+    assert isinstance(cose_key, RSAKey)


### PR DESCRIPTION
Addresses one half of #44.

Note on tests: The existing tests are a bit inconsistent between key types and I didn't want to change that in this PR which is why the new tests keep the existing style within each test file but may look a bit odd as a set.