### PR TITLE
Support detached content for signing

### DIFF
--- a/docs/pycose/messages/sign1message.rst
+++ b/docs/pycose/messages/sign1message.rst
@@ -1,9 +1,12 @@
 Sign1
 =====
 
-:class:`~pycose.messages.sign1message.Sign1Message` messages are used when there is single signature attached to the basic
+:class:`~pycose.messages.sign1message.Sign1Message` messages are used when there is a single signature attached to the basic
 COSE structure, consisting of headers and payload. Receivers must implicitly know the public key to verify the message
 since no additional key information is transported.
+
+The payload can either be included in the message or remain detached.
+Detached payloads must be provided as `detached_payload` argument during signing and verification.
 
 .. image:: ../../../images/sign1.png
     :width: 650px

--- a/docs/pycose/messages/signmessage.rst
+++ b/docs/pycose/messages/signmessage.rst
@@ -5,9 +5,19 @@ Sign
 required to validate the message signature. The basic COSE structure, consisting of headers and payload,
 is extended with a list of :class:`~pycose.messages.signer.CoseSignature` structures.
 
+The payload can either be included in the message or remain detached.
+Detached payloads must be provided as `detached_payload` argument during signing and verification.
+
 .. module:: pycose.messages.signmessage
 
 .. autoclass:: SignMessage
+    :members:
+    :inherited-members:
+    :exclude-members: from_cose_obj, record_cbor_tag
+
+.. module:: pycose.messages.signer
+
+.. autoclass:: CoseSignature
     :members:
     :inherited-members:
     :exclude-members: from_cose_obj, record_cbor_tag

--- a/pycose/messages/cosebase.py
+++ b/pycose/messages/cosebase.py
@@ -24,7 +24,7 @@ class CoseBase(metaclass=abc.ABCMeta):
 
         return cls(phdr_encoded=phdr_encoded, uhdr=uhdr, allow_unknown_attributes=allow_unknown_attributes)
 
-    def __init__(self, phdr: Optional[dict] = None, uhdr: Optional[dict] = None, payload: bytes = b'', phdr_encoded: Optional[bytes] = None, *args, **kwargs):
+    def __init__(self, phdr: Optional[dict] = None, uhdr: Optional[dict] = None, payload: Optional[bytes] = None, phdr_encoded: Optional[bytes] = None, *args, **kwargs):
         if phdr is not None and phdr_encoded is not None:
             raise ValueError("Cannot have both phdr and phdr_encoded")
         
@@ -54,7 +54,7 @@ class CoseBase(metaclass=abc.ABCMeta):
         self._uhdr = CoseBase._parse_header(uhdr, kwargs.get("allow_unknown_attributes", True))
 
         # can be plaintext or ciphertext
-        if type(payload) is not bytes:
+        if payload is not None and type(payload) is not bytes:
             raise TypeError("payload should be of type 'bytes'")
         self._payload = payload
 

--- a/pycose/messages/cosemessage.py
+++ b/pycose/messages/cosemessage.py
@@ -84,7 +84,7 @@ class CoseMessage(CoseBase, metaclass=abc.ABCMeta):
     def __init__(self,
                  phdr: Optional[dict] = None,
                  uhdr: Optional[dict] = None,
-                 payload: bytes = b'',
+                 payload: Optional[bytes] = None,
                  external_aad: bytes = b'',
                  key: Optional[CoseKey] = None,
                  *args,
@@ -128,12 +128,12 @@ class CoseMessage(CoseBase, metaclass=abc.ABCMeta):
             self._key = key
 
     @property
-    def payload(self) -> bytes:
+    def payload(self) -> Optional[bytes]:
         return self._payload
 
     @payload.setter
-    def payload(self, new_payload: bytes) -> None:
-        if type(new_payload) is not bytes:
+    def payload(self, new_payload: Optional[bytes]) -> None:
+        if new_payload is not None and type(new_payload) is not bytes:
             raise TypeError("payload should be of type 'bytes' not {}".format(type(new_payload)))
         self._payload = new_payload  # can be plaintext or ciphertext
 

--- a/pycose/messages/sign1message.py
+++ b/pycose/messages/sign1message.py
@@ -66,17 +66,12 @@ class Sign1Message(SignCommon):
     def encode(self, tag: bool = True, sign: bool = True, detached_payload: Optional[bytes] = None, *args, **kwargs) -> CBOR:
         """ Encodes the message into a CBOR array with or without a CBOR tag. """
 
-        if detached_payload is None:
-            payload = self.payload
-        else:
-            payload = None
-
         if sign:
-            message = [self.phdr_encoded, self.uhdr_encoded, payload, self.compute_signature(detached_payload)]
+            message = [self.phdr_encoded, self.uhdr_encoded, self.payload, self.compute_signature(detached_payload)]
         elif self.signature:
-            message = [self.phdr_encoded, self.uhdr_encoded, payload, self.signature]
+            message = [self.phdr_encoded, self.uhdr_encoded, self.payload, self.signature]
         else:
-            message = [self.phdr_encoded, self.uhdr_encoded, payload]
+            message = [self.phdr_encoded, self.uhdr_encoded, self.payload]
 
         if tag:
             res = cbor2.dumps(cbor2.CBORTag(self.cbor_tag, message), default=self._custom_cbor_encoder)

--- a/pycose/messages/sign1message.py
+++ b/pycose/messages/sign1message.py
@@ -5,6 +5,7 @@ import cbor2
 from pycose import utils
 from pycose.messages.cosemessage import CoseMessage
 from pycose.messages.signcommon import SignCommon
+from pycose.exceptions import CoseException
 
 if TYPE_CHECKING:
     from pycose.keys.ec2 import EC2
@@ -28,7 +29,7 @@ class Sign1Message(SignCommon):
     def __init__(self,
                  phdr: Optional[dict] = None,
                  uhdr: Optional[dict] = None,
-                 payload: bytes = b'',
+                 payload: Optional[bytes] = None,
                  external_aad: bytes = b'',
                  key: Optional[Union['EC2', 'OKP', 'RSA']] = None,
                  *args,
@@ -42,7 +43,7 @@ class Sign1Message(SignCommon):
     def signature(self):
         return self._signature
 
-    def _create_sig_structure(self, payload: Optional[bytes] = None):
+    def _create_sig_structure(self, detached_payload: Optional[bytes] = None):
         """
         Create the sig_structure that needs to be signed
 
@@ -51,23 +52,27 @@ class Sign1Message(SignCommon):
         sig_structure = [self.context]
         sig_structure = self._base_structure(sig_structure)
 
-        if payload is None:
+        if detached_payload is None:
+            if self.payload is None:
+                raise CoseException("Missing payload and no detached payload provided")
             sig_structure.append(self.payload)
         else:
-            sig_structure.append(payload)
+            if self.payload is not None:
+                raise CoseException("Detached payload must be None when payload is set")
+            sig_structure.append(detached_payload)
 
         return cbor2.dumps(sig_structure)
 
-    def encode(self, tag: bool = True, sign: bool = True, detached: bool = False, *args, **kwargs) -> CBOR:
+    def encode(self, tag: bool = True, sign: bool = True, detached_payload: Optional[bytes] = None, *args, **kwargs) -> CBOR:
         """ Encodes the message into a CBOR array with or without a CBOR tag. """
 
-        if detached:
-            payload = None
-        else:
+        if detached_payload is None:
             payload = self.payload
+        else:
+            payload = None
 
         if sign:
-            message = [self.phdr_encoded, self.uhdr_encoded, payload, self.compute_signature()]
+            message = [self.phdr_encoded, self.uhdr_encoded, payload, self.compute_signature(detached_payload)]
         elif self.signature:
             message = [self.phdr_encoded, self.uhdr_encoded, payload, self.signature]
         else:

--- a/pycose/messages/signcommon.py
+++ b/pycose/messages/signcommon.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Type, TYPE_CHECKING
+from typing import Optional, Type, TYPE_CHECKING
 
 from pycose import headers
 from pycose.keys.okp import OKPKey
@@ -19,8 +19,7 @@ class SignCommon(CoseMessage, metaclass=abc.ABCMeta):
     def signature(self):
         raise NotImplementedError
 
-    @property
-    def _sig_structure(self):
+    def _create_sig_structure(self, payload: Optional[bytes] = None) -> bytes:
         raise NotImplementedError
 
     def _key_verification(self, alg: Type['CoseAlg'], ops: Type['KEYOPS']):
@@ -37,7 +36,7 @@ class SignCommon(CoseMessage, metaclass=abc.ABCMeta):
         else:
             raise CoseException('Wrong key type')
 
-    def verify_signature(self, *args, **kwargs) -> bool:
+    def verify_signature(self, payload: Optional[bytes] = None, *args, **kwargs) -> bool:
         """
         Verifies the signature of a received COSE message.
 
@@ -47,7 +46,7 @@ class SignCommon(CoseMessage, metaclass=abc.ABCMeta):
 
         self._key_verification(alg, VerifyOp)
 
-        return alg.verify(key=self.key, data=self._sig_structure, signature=self.signature)
+        return alg.verify(key=self.key, data=self._create_sig_structure(payload), signature=self.signature)
 
     def compute_signature(self, *args, **kwargs) -> bytes:
         """
@@ -60,4 +59,4 @@ class SignCommon(CoseMessage, metaclass=abc.ABCMeta):
 
         self._key_verification(alg, SignOp)
 
-        return alg.sign(key=self.key, data=self._sig_structure)
+        return alg.sign(key=self.key, data=self._create_sig_structure())

--- a/pycose/messages/signcommon.py
+++ b/pycose/messages/signcommon.py
@@ -19,7 +19,7 @@ class SignCommon(CoseMessage, metaclass=abc.ABCMeta):
     def signature(self):
         raise NotImplementedError
 
-    def _create_sig_structure(self, payload: Optional[bytes] = None) -> bytes:
+    def _create_sig_structure(self, detached_payload: Optional[bytes] = None) -> bytes:
         raise NotImplementedError
 
     def _key_verification(self, alg: Type['CoseAlg'], ops: Type['KEYOPS']):
@@ -36,7 +36,7 @@ class SignCommon(CoseMessage, metaclass=abc.ABCMeta):
         else:
             raise CoseException('Wrong key type')
 
-    def verify_signature(self, payload: Optional[bytes] = None, *args, **kwargs) -> bool:
+    def verify_signature(self, detached_payload: Optional[bytes] = None, *args, **kwargs) -> bool:
         """
         Verifies the signature of a received COSE message.
 
@@ -46,9 +46,9 @@ class SignCommon(CoseMessage, metaclass=abc.ABCMeta):
 
         self._key_verification(alg, VerifyOp)
 
-        return alg.verify(key=self.key, data=self._create_sig_structure(payload), signature=self.signature)
+        return alg.verify(key=self.key, data=self._create_sig_structure(detached_payload), signature=self.signature)
 
-    def compute_signature(self, *args, **kwargs) -> bytes:
+    def compute_signature(self, detached_payload: Optional[bytes] = None, *args, **kwargs) -> bytes:
         """
         Computes the signature over a COSE message.
 
@@ -59,4 +59,4 @@ class SignCommon(CoseMessage, metaclass=abc.ABCMeta):
 
         self._key_verification(alg, SignOp)
 
-        return alg.sign(key=self.key, data=self._create_sig_structure())
+        return alg.sign(key=self.key, data=self._create_sig_structure(detached_payload))

--- a/pycose/messages/signer.py
+++ b/pycose/messages/signer.py
@@ -48,15 +48,18 @@ class CoseSignature(SignCommon):
 
         self._payload = value
 
-    @property
-    def _sig_structure(self):
+    def _create_sig_structure(self, payload: Optional[bytes] = None):
         sign_structure = [self._parent.context, self._parent.phdr_encoded]
 
         if len(self.phdr):
             sign_structure.append(self.phdr_encoded)
 
         sign_structure.append(self.external_aad)
-        sign_structure.append(self._parent.payload)
+
+        if payload is None:
+            sign_structure.append(self._parent.payload)
+        else:
+            sign_structure.append(payload)
 
         aad = cbor2.dumps(sign_structure)
         return aad

--- a/pycose/messages/signmessage.py
+++ b/pycose/messages/signmessage.py
@@ -54,7 +54,12 @@ class _SignMessage(CoseMessage, metaclass=abc.ABCMeta):
             self.signers = signers
 
     @property
-    def signers(self):
+    def signers(self) -> List['Signer']:
+        """
+        The signers of the message.
+
+        :returns: Returns the list of signers as CoseSignature objects.
+        """
         return self._signers
 
     @signers.setter

--- a/pycose/messages/signmessage.py
+++ b/pycose/messages/signmessage.py
@@ -74,12 +74,7 @@ class _SignMessage(CoseMessage, metaclass=abc.ABCMeta):
     def encode(self, tag: bool = True, detached_payload: Optional[bytes] = None, *args, **kwargs) -> bytes:
         """ Encodes and protects the COSE_Sign message. """
 
-        if detached_payload is None:
-            payload = self.payload
-        else:
-            payload = None
-
-        message = [self.phdr_encoded, self.uhdr_encoded, payload]
+        message = [self.phdr_encoded, self.uhdr_encoded, self.payload]
 
         if len(self.signers):
             message.append([s.encode(detached_payload) for s in self.signers])

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -243,6 +243,7 @@ def test_allow_unknown_header_attribute_encoding_decoding():
 
     msg = SignMessage(phdr={"Custom-Header-Attr1": 7879},
                       uhdr={KID: b'foo', IV: unhexlify(b'00000000000000000000000000'), "Custom-Header-Attr2": 878},
+                      payload=b"",
                       signers=[CoseSignature(phdr={Algorithm: Es256, "Custom-Header-Attr3": 9999},
                                              key=EC2Key.generate_key(crv=P256))])
 

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -258,7 +258,8 @@ def test_allow_unknown_header_attribute_encoding_decoding():
     assert "Custom-Header-Attr3" in msg_decoded.signers[0].phdr
 
     msg = Sign1Message(phdr={Algorithm: Es256, "Custom-Header-Attr1": 7879},
-                       uhdr={KID: b'foo', "Custom-Header-Attr2": 878})
+                       uhdr={KID: b'foo', "Custom-Header-Attr2": 878},
+                       payload=b"")
     msg.key = EC2Key.generate_key(crv=P256)
 
     assert "Custom-Header-Attr1" in msg.phdr
@@ -277,7 +278,7 @@ def test_no_reencoding_of_protected_header():
     # This is a test to ensure that the protected header is not re-encoded.
     phdr_encoded = unhexlify(b'A2012663666F6F190001')
 
-    msg = Sign1Message(phdr_encoded=phdr_encoded)
+    msg = Sign1Message(phdr_encoded=phdr_encoded, payload=b"")
     msg.key = EC2Key.generate_key(crv=P256)
 
     msg = msg.encode()

--- a/tests/test_cosemessage.py
+++ b/tests/test_cosemessage.py
@@ -8,7 +8,7 @@ from pycose.messages import CoseMessage, Enc0Message, Sign1Message
 
 @pytest.fixture
 def sign1_message():
-    msg = Sign1Message(phdr={Algorithm: Es256})
+    msg = Sign1Message(phdr={Algorithm: Es256}, payload=b"")
     msg.key = EC2Key.generate_key(crv=P256)
     return msg.encode()
 

--- a/tests/test_sign1message.py
+++ b/tests/test_sign1message.py
@@ -119,7 +119,7 @@ def test_detach_payload():
     assert msg.signature == sig
 
 
-def test_fail_sign_if_missing_payload():
+def test_fail_on_missing_payload_signing():
     ec2_key = EC2Key.generate_key(crv='P_256', optional_params={'ALG': 'ES256'})
 
     msg = Sign1Message(phdr={'ALG': 'ES256'})
@@ -129,7 +129,7 @@ def test_fail_sign_if_missing_payload():
         msg.encode()
 
 
-def test_fail_verify_if_missing_payload():
+def test_fail_on_missing_payload_verification():
     ec2_key = EC2Key.generate_key(crv='P_256', optional_params={'ALG': 'ES256'})
 
     payload = "signed message".encode('utf-8')

--- a/tests/test_sign1message.py
+++ b/tests/test_sign1message.py
@@ -66,7 +66,7 @@ def test_detached_payload():
 
     assert msg.payload is None
 
-    msg.verify_signature(detached_payload=payload)
+    assert msg.verify_signature(detached_payload=payload)
 
 
 def test_attach_payload():
@@ -88,7 +88,7 @@ def test_attach_payload():
     # Decode and verify
     msg = Sign1Message.decode(encoded)
     msg.key = ec2_key
-    msg.verify_signature()
+    assert msg.verify_signature()
 
     # Make sure re-encoding didn't change the signature
     assert msg.signature == sig
@@ -113,7 +113,7 @@ def test_detach_payload():
     # Decode and verify
     msg = Sign1Message.decode(encoded)
     msg.key = ec2_key
-    msg.verify_signature(detached_payload=payload)
+    assert msg.verify_signature(detached_payload=payload)
 
     # Make sure re-encoding didn't change the signature
     assert msg.signature == sig

--- a/tests/test_signmessage.py
+++ b/tests/test_signmessage.py
@@ -3,7 +3,10 @@ from binascii import hexlify, unhexlify
 import cbor2
 import pytest
 
+from pycose.keys import EC2Key
 from pycose.messages.signmessage import SignMessage
+from pycose.messages.signer import CoseSignature
+from pycose.exceptions import CoseException
 from tests.conftest import _setup_signers
 
 
@@ -56,3 +59,58 @@ def test_sign_decoding(test_sign):
         s.key = s_input['signing_key']
         assert hexlify(s._create_sig_structure()) == hexlify(s_output['structure'])
         assert s.verify_signature()
+
+
+def test_detached_payload():
+    ec2_key = EC2Key.generate_key(crv='P_256', optional_params={'ALG': 'ES256'})
+
+    payload = "signed message".encode('utf-8')
+
+    signer = CoseSignature(phdr={'ALG': 'ES256'})
+    signer.key = ec2_key
+
+    msg = SignMessage(phdr={}, signers=[signer])
+
+    encoded = msg.encode(detached_payload=payload)
+
+    msg = SignMessage.decode(encoded)
+    
+    assert msg.payload is None
+    
+    signer = msg.signers[0]
+    signer.key = ec2_key
+
+    assert signer.verify_signature(detached_payload=payload)
+
+
+def test_fail_on_missing_payload_signing():
+    ec2_key = EC2Key.generate_key(crv='P_256', optional_params={'ALG': 'ES256'})
+
+    signer = CoseSignature(phdr={'ALG': 'ES256'})
+    signer.key = ec2_key
+
+    msg = SignMessage(phdr={}, signers=[signer])
+
+    with pytest.raises(CoseException, match="Missing payload"):
+        msg.encode()
+
+
+def test_fail_on_missing_payload_verification():
+    ec2_key = EC2Key.generate_key(crv='P_256', optional_params={'ALG': 'ES256'})
+
+    payload = "signed message".encode('utf-8')
+
+    signer = CoseSignature(phdr={'ALG': 'ES256'})
+    signer.key = ec2_key
+
+    msg = SignMessage(phdr={}, signers=[signer])
+
+    encoded = msg.encode(detached_payload=payload)
+
+    msg = SignMessage.decode(encoded)
+
+    signer = msg.signers[0]
+    signer.key = ec2_key
+
+    with pytest.raises(CoseException, match="Missing payload"):
+        signer.verify_signature()

--- a/tests/test_signmessage.py
+++ b/tests/test_signmessage.py
@@ -23,7 +23,7 @@ def test_sign_encoding(test_sign):
     assert msg.uhdr == test_input['unprotected']
 
     for s, s_output in zip(msg.signers, test_output['signers']):
-        assert hexlify(s._sig_structure) == hexlify(s_output['structure'])
+        assert hexlify(s._create_sig_structure()) == hexlify(s_output['structure'])
         if 'signature' in s_output:
             assert s.compute_signature() == s_output['signature']
 
@@ -54,5 +54,5 @@ def test_sign_decoding(test_sign):
     for s, s_input, s_output in zip(msg.signers, test_input['signers'], test_output['signers']):
         s.external_aad = unhexlify(s_input['external_aad'])
         s.key = s_input['signing_key']
-        assert hexlify(s._sig_structure) == hexlify(s_output['structure'])
+        assert hexlify(s._create_sig_structure()) == hexlify(s_output['structure'])
         assert s.verify_signature()


### PR DESCRIPTION
Closes #81.

This test for COSE_Sign1 illustrates the additions:

```py
def test_sign1_detached_payload():
    ec2_key = EC2Key.generate_key(crv='P_256', optional_params={'ALG': 'ES256'})

    msg = Sign1Message(phdr={'ALG': 'ES256'})
    msg.key = ec2_key

    with pytest.raises(CoseException, match="Missing payload"):
        msg.encode()

    encoded = msg.encode(detached_payload="signed message".encode('utf-8'))

    msg = Sign1Message.decode(encoded)
    msg.key = ec2_key

    assert msg.payload is None

    with pytest.raises(CoseException, match="Missing payload"):
        msg.verify_signature()

    msg.verify_signature(detached_payload="signed message".encode('utf-8'))
```

cc @becarpenter @BrianSipos