### PR TITLE
Add `signature` setter to `Sign1Message`

### DIFF
--- a/pycose/messages/sign1message.py
+++ b/pycose/messages/sign1message.py
@@ -42,6 +42,13 @@ class Sign1Message(SignCommon):
     @property
     def signature(self):
         return self._signature
+    
+    @signature.setter
+    def signature(self, value):
+        if not isinstance(value, bytes):
+            raise TypeError("Signature must be of type 'bytes'")
+
+        self._signature = value
 
     def _create_sig_structure(self, detached_payload: Optional[bytes] = None):
         """


### PR DESCRIPTION
Closes #105.

Note that `Signer` (for `CoseSign`) already has a setter for `signature`, so this brings parity between the classes.