### PR TITLE
Broaden type spec for CoseMessage.decode

### DIFF
--- a/pycose/messages/cosemessage.py
+++ b/pycose/messages/cosemessage.py
@@ -33,7 +33,7 @@ class CoseMessage(CoseBase, metaclass=abc.ABCMeta):
         return decorator
 
     @classmethod
-    def decode(cls: Type['CM'], received: bytes, *args, **kwargs) -> 'CM':
+    def decode(cls: Type['CM'], received: bytes | bytearray | memoryview, *args, **kwargs) -> 'CM':
         """
         Decode received COSE message based on the CBOR tag.
 


### PR DESCRIPTION
The data provided here as `received` is passed directly to cbor2 which allows for bytearrays and memoryviews in addition to bytes.