### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 [![Python package](https://github.com/TimothyClaeys/pycose/actions/workflows/python-package.yml/badge.svg)](https://github.com/TimothyClaeys/pycose/actions/workflows/python-package.yml)
 [![Documentation Status](https://readthedocs.org/projects/pycose/badge/?version=latest)](https://pycose.readthedocs.io/en/latest/?badge=latest)
 
-This project is a Python implementation of the IETF CBOR Encoded Message Syntax (COSE). COSE has reached RFC status and is now available at RFC 8152.
-
+This project is a Python implementation of the IETF CBOR Encoded Message Syntax (COSE). COSE has reached RFC status and is now specified in RFC 9052 and RFC 9053.
 
 ## Installation
 
@@ -12,7 +11,7 @@ $ pip install pycose
 ```
 
 ## What is COSE ?
-CBOR Encoded Message Syntax (COSE) is a data format for concise representation of small messages [RFC 8152](https://tools.ietf.org/html/rfc8152). COSE is optimized for low power devices. The messages can be encrypted, MAC'ed and signed. There are 6 different types of COSE messages:
+CBOR Encoded Message Syntax (COSE) is a data format for concise representation of small messages [RFC 9052](https://datatracker.ietf.org/doc/rfc9052/). COSE is optimized for low power devices. The messages can be encrypted, MAC'ed and signed. There are 6 different types of COSE messages:
 
 - **Encrypt0**: An encrypted COSE message with a single recipient. The payload and AAD are protected by a shared CEK (Content Encryption Keys)
 - **Encrypt**: An encrypted COSE message can have multiple recipients. For each recipient the CEK is encrypted with a KEK (Key Encryption Key) - using AES key wrap - and added to the message.

--- a/pycose/algorithms.py
+++ b/pycose/algorithms.py
@@ -984,7 +984,7 @@ class DirectHKDFAES256(CoseAlgorithm):
     fullname = "DIRECT_HKDF_AES_256"
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1001,7 +1001,7 @@ class DirectHKDFAES128(CoseAlgorithm):
     fullname = "DIRECT_HKDF_AES_128"
     
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1113,7 +1113,7 @@ class Direct(CoseAlgorithm):
     fullname = "DIRECT"
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return False
 
 @CoseAlgorithm.register_attribute()
@@ -1135,7 +1135,7 @@ class A256KW(_AesKw):
         return 32
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return False
 
 @CoseAlgorithm.register_attribute()
@@ -1157,7 +1157,7 @@ class A192KW(_AesKw):
         return 24
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return False
 
 @CoseAlgorithm.register_attribute()
@@ -1179,7 +1179,7 @@ class A128KW(_AesKw):
         return 16
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return False
 
 @CoseAlgorithm.register_attribute()
@@ -1205,7 +1205,7 @@ class A128GCM(_AesGcm):
         return 12
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1231,7 +1231,7 @@ class A192GCM(_AesGcm):
         return 12
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1257,7 +1257,7 @@ class A256GCM(_AesGcm):
         return 12
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1334,7 +1334,7 @@ class AESCCM1664128(_AesCcm):
         return 13
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1355,7 +1355,7 @@ class AESCCM1664256(_AesCcm):
         return 13
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 
@@ -1377,7 +1377,7 @@ class AESCCM6464128(_AesCcm):
         return 7
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 
@@ -1399,7 +1399,7 @@ class AESCCM6464256(_AesCcm):
         return 7
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1416,7 +1416,7 @@ class AESMAC12864(_AesMac):
         return 16
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1433,7 +1433,7 @@ class AESMAC25664(_AesMac):
         return 32
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1450,7 +1450,7 @@ class AESMAC128128(_AesMac):
         return 16
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1467,7 +1467,7 @@ class AESMAC256128(_AesMac):
         return 32
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1485,7 +1485,7 @@ class AESCCM16128128(_AesCcm):
         return 16
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1502,7 +1502,7 @@ class AESCCM16128256(_AesCcm):
         return 32
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1519,7 +1519,7 @@ class AESCCM64128128(_AesCcm):
         return 16
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 @CoseAlgorithm.register_attribute()
@@ -1536,7 +1536,7 @@ class AESCCM64128256(_AesCcm):
         return 32
 
     @classmethod
-    def has_authentication() -> bool:
+    def has_authentication(cls) -> bool:
         return True
 
 # set parser

--- a/pycose/algorithms.py
+++ b/pycose/algorithms.py
@@ -314,11 +314,19 @@ class _AesGcm(_EncAlg, ABC):
 
     @classmethod
     def encrypt(cls, key: 'SK', nonce: bytes, data: bytes, aad: bytes) -> bytes:
+        if len(key.k) != cls.get_key_length():
+            raise ValueError("Key has the wrong length")
+        if len(nonce) != cls.get_nonce_length():
+            raise ValueError("Nonce has the wrong length")
         cipher = AESGCM(key=key.k)
         return cipher.encrypt(nonce=nonce, data=data, associated_data=aad)
 
     @classmethod
     def decrypt(cls, key: 'SK', nonce: bytes, ciphertext: bytes, aad: bytes) -> bytes:
+        if len(key.k) != cls.get_key_length():
+            raise ValueError("Key has the wrong length")
+        if len(nonce) != cls.get_nonce_length():
+            raise ValueError("Nonce has the wrong length")
         cipher = AESGCM(key=key.k)
         return cipher.decrypt(nonce=nonce, data=ciphertext, associated_data=aad)
 
@@ -332,11 +340,19 @@ class _AesCcm(_EncAlg, ABC):
 
     @classmethod
     def encrypt(cls, key: 'SK', nonce: bytes, data: bytes, aad: bytes) -> bytes:
+        if len(key.k) != cls.get_key_length():
+            raise ValueError("Key has the wrong length")
+        if len(nonce) != cls.get_nonce_length():
+            raise ValueError("Nonce has the wrong length")
         cipher = AESCCM(key.k, tag_length=cls.get_tag_length())
         return cipher.encrypt(nonce, data=data, associated_data=aad)
 
     @classmethod
     def decrypt(cls, key: 'SK', nonce: bytes, ciphertext: bytes, aad: bytes) -> bytes:
+        if len(key.k) != cls.get_key_length():
+            raise ValueError("Key has the wrong length")
+        if len(nonce) != cls.get_nonce_length():
+            raise ValueError("Nonce has the wrong length")
         cipher = AESCCM(key=key.k, tag_length=cls.get_tag_length())
         return cipher.decrypt(nonce, data=ciphertext, associated_data=aad)
 
@@ -1154,6 +1170,10 @@ class A128GCM(_AesGcm):
     @classmethod
     def get_key_length(cls) -> int:
         return 16
+    
+    @classmethod
+    def get_nonce_length(cls) -> int:
+        return 12
 
 
 @CoseAlgorithm.register_attribute()
@@ -1173,6 +1193,10 @@ class A192GCM(_AesGcm):
     @classmethod
     def get_key_length(cls) -> int:
         return 24
+    
+    @classmethod
+    def get_nonce_length(cls) -> int:
+        return 12
 
 
 @CoseAlgorithm.register_attribute()
@@ -1192,6 +1216,10 @@ class A256GCM(_AesGcm):
     @classmethod
     def get_key_length(cls) -> int:
         return 32
+
+    @classmethod
+    def get_nonce_length(cls) -> int:
+        return 12
 
 
 @CoseAlgorithm.register_attribute()
@@ -1262,6 +1290,10 @@ class AESCCM1664128(_AesCcm):
     @classmethod
     def get_key_length(cls) -> int:
         return 16
+    
+    @classmethod
+    def get_nonce_length(cls) -> int:
+        return 13
 
 
 @CoseAlgorithm.register_attribute()
@@ -1276,6 +1308,11 @@ class AESCCM1664256(_AesCcm):
     @classmethod
     def get_key_length(cls) -> int:
         return 32
+     
+    @classmethod
+    def get_nonce_length(cls) -> int:
+        return 13
+
 
 
 @CoseAlgorithm.register_attribute()
@@ -1291,6 +1328,11 @@ class AESCCM6464128(_AesCcm):
     def get_key_length(cls) -> int:
         return 16
 
+    @classmethod
+    def get_nonce_length(cls) -> int:
+        return 7
+
+
 
 @CoseAlgorithm.register_attribute()
 class AESCCM6464256(_AesCcm):
@@ -1304,6 +1346,10 @@ class AESCCM6464256(_AesCcm):
     @classmethod
     def get_tag_length(cls) -> int:
         return 8
+
+    @classmethod
+    def get_nonce_length(cls) -> int:
+        return 7
 
 
 @CoseAlgorithm.register_attribute()

--- a/pycose/algorithms.py
+++ b/pycose/algorithms.py
@@ -494,6 +494,10 @@ class RsaesOaepSha512(_RsaOaep):
     def get_hash_func(cls):
         return SHA512
 
+    @classmethod
+    def has_authentication(cls) -> bool:
+        return False
+
 
 @CoseAlgorithm.register_attribute()
 class RsaesOaepSha256(_RsaOaep):
@@ -504,6 +508,9 @@ class RsaesOaepSha256(_RsaOaep):
     def get_hash_func(cls):
         return SHA256
 
+    @classmethod
+    def has_authentication(cls) -> bool:
+        return False
 
 @CoseAlgorithm.register_attribute()
 class RsaesOaepSha1(_RsaOaep):
@@ -513,6 +520,10 @@ class RsaesOaepSha1(_RsaOaep):
     @classmethod
     def get_hash_func(cls):
         return SHA1
+
+    @classmethod
+    def has_authentication(cls) -> bool:
+        return False
 
 
 @CoseAlgorithm.register_attribute()

--- a/pycose/algorithms.py
+++ b/pycose/algorithms.py
@@ -972,6 +972,9 @@ class DirectHKDFAES256(CoseAlgorithm):
     identifier = - 13
     fullname = "DIRECT_HKDF_AES_256"
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class DirectHKDFAES128(CoseAlgorithm):
@@ -985,7 +988,10 @@ class DirectHKDFAES128(CoseAlgorithm):
     """
     identifier = - 12
     fullname = "DIRECT_HKDF_AES_128"
-
+    
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class DirecHKDFSHA512(CoseAlgorithm):
@@ -1095,6 +1101,9 @@ class Direct(CoseAlgorithm):
     identifier = -6
     fullname = "DIRECT"
 
+    @classmethod
+    def has_authentication() -> bool:
+        return False
 
 @CoseAlgorithm.register_attribute()
 class A256KW(_AesKw):
@@ -1114,6 +1123,9 @@ class A256KW(_AesKw):
     def get_key_length(cls) -> int:
         return 32
 
+    @classmethod
+    def has_authentication() -> bool:
+        return False
 
 @CoseAlgorithm.register_attribute()
 class A192KW(_AesKw):
@@ -1133,6 +1145,9 @@ class A192KW(_AesKw):
     def get_key_length(cls) -> int:
         return 24
 
+    @classmethod
+    def has_authentication() -> bool:
+        return False
 
 @CoseAlgorithm.register_attribute()
 class A128KW(_AesKw):
@@ -1152,6 +1167,9 @@ class A128KW(_AesKw):
     def get_key_length(cls) -> int:
         return 16
 
+    @classmethod
+    def has_authentication() -> bool:
+        return False
 
 @CoseAlgorithm.register_attribute()
 class A128GCM(_AesGcm):
@@ -1170,11 +1188,14 @@ class A128GCM(_AesGcm):
     @classmethod
     def get_key_length(cls) -> int:
         return 16
-    
+
     @classmethod
     def get_nonce_length(cls) -> int:
         return 12
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class A192GCM(_AesGcm):
@@ -1198,6 +1219,9 @@ class A192GCM(_AesGcm):
     def get_nonce_length(cls) -> int:
         return 12
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class A256GCM(_AesGcm):
@@ -1221,6 +1245,9 @@ class A256GCM(_AesGcm):
     def get_nonce_length(cls) -> int:
         return 12
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class HMAC25664(_HMAC):
@@ -1295,6 +1322,9 @@ class AESCCM1664128(_AesCcm):
     def get_nonce_length(cls) -> int:
         return 13
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESCCM1664256(_AesCcm):
@@ -1313,6 +1343,9 @@ class AESCCM1664256(_AesCcm):
     def get_nonce_length(cls) -> int:
         return 13
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 
 @CoseAlgorithm.register_attribute()
@@ -1332,6 +1365,9 @@ class AESCCM6464128(_AesCcm):
     def get_nonce_length(cls) -> int:
         return 7
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 
 @CoseAlgorithm.register_attribute()
@@ -1351,6 +1387,9 @@ class AESCCM6464256(_AesCcm):
     def get_nonce_length(cls) -> int:
         return 7
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESMAC12864(_AesMac):
@@ -1365,6 +1404,9 @@ class AESMAC12864(_AesMac):
     def get_key_length(cls) -> int:
         return 16
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESMAC25664(_AesMac):
@@ -1379,6 +1421,9 @@ class AESMAC25664(_AesMac):
     def get_key_length(cls) -> int:
         return 32
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESMAC128128(_AesMac):
@@ -1393,6 +1438,9 @@ class AESMAC128128(_AesMac):
     def get_key_length(cls) -> int:
         return 16
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESMAC256128(_AesMac):
@@ -1407,6 +1455,9 @@ class AESMAC256128(_AesMac):
     def get_key_length(cls) -> int:
         return 32
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESCCM16128128(_AesCcm):
@@ -1422,6 +1473,9 @@ class AESCCM16128128(_AesCcm):
     def get_key_length(cls) -> int:
         return 16
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESCCM16128256(_AesCcm):
@@ -1436,6 +1490,9 @@ class AESCCM16128256(_AesCcm):
     def get_key_length(cls) -> int:
         return 32
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESCCM64128128(_AesCcm):
@@ -1450,6 +1507,9 @@ class AESCCM64128128(_AesCcm):
     def get_key_length(cls) -> int:
         return 16
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 @CoseAlgorithm.register_attribute()
 class AESCCM64128256(_AesCcm):
@@ -1464,6 +1524,9 @@ class AESCCM64128256(_AesCcm):
     def get_key_length(cls) -> int:
         return 32
 
+    @classmethod
+    def has_authentication() -> bool:
+        return True
 
 # set parser
 Algorithm.value_parser = CoseAlgorithm.from_id

--- a/pycose/headers.py
+++ b/pycose/headers.py
@@ -182,11 +182,18 @@ def crit_is_array(value: Any):
     return value
 
 
-def content_type_is_uint_or_tstr(value: Any):
-    if (not isinstance(value, int) and not isinstance(value, str)) or (
-            True if isinstance(value, int) and value < 0 else False):
-        raise ValueError("CONTENT TYPE should be an unsigned integer or string")
-
+def content_type_is_uint_or_tstr(value):
+    if isinstance(value, int):
+        if value < 0:
+            raise ValueError("CONTENT TYPE must be a non-negative integer or a string")
+    elif isinstance(value, str):
+        if value != value.strip():
+            raise ValueError("CONTENT TYPE string must not have leading or trailing whitespace")
+        parts = value.split('/')
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise ValueError("CONTENT TYPE string must follow 'type/subtype' format")
+    else:
+        raise ValueError("CONTENT TYPE must be a non-negative integer or a string")
     return value
 
 

--- a/pycose/messages/cosemessage.py
+++ b/pycose/messages/cosemessage.py
@@ -4,6 +4,7 @@ from typing import Optional, TypeVar, Type, TYPE_CHECKING
 import cbor2
 
 from pycose.exceptions import CoseInvalidKey
+from pycose.headers import Algorithm, Critical
 from pycose.keys import CoseKey
 from pycose.keys.ec2 import EC2Key
 from pycose.keys.okp import OKPKey
@@ -139,6 +140,10 @@ class CoseMessage(CoseBase, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def encode(self, message: list, tag: bool = True, *args, **kwargs) -> CBOR:
+        if Critical in self.uhdr:
+            raise ValueError("The crit parameter must be set in the protected header.")
+        if Algorithm in self.uhdr:
+            raise ValueError("The alg parameter must also be in the protected header.")
         if tag:
             message = cbor2.dumps(cbor2.CBORTag(self.cbor_tag, message), default=self._custom_cbor_encoder)
         else:

--- a/pycose/messages/enc0message.py
+++ b/pycose/messages/enc0message.py
@@ -10,6 +10,7 @@ COSE_Encrypt0 = [
 from typing import Optional, TYPE_CHECKING
 
 from pycose import utils
+from pycose.headers import Algorithm
 from pycose.messages import enccommon, cosemessage
 
 if TYPE_CHECKING:
@@ -59,6 +60,9 @@ class Enc0Message(enccommon.EncCommon):
 
         :return: Returns a CBOR-encoded COSE Encrypt0 message.
         """
+
+        if Algorithm in self.uhdr and self.get_attr(Algorithm).has_authentication():
+            raise ValueError("Algorithems that support authentication must be placed in the protected header.")
 
         if encrypt:
             message = [self.phdr_encoded, self.uhdr_encoded, self.encrypt()]

--- a/pycose/messages/enc0message.py
+++ b/pycose/messages/enc0message.py
@@ -64,6 +64,9 @@ class Enc0Message(enccommon.EncCommon):
         if Algorithm in self.uhdr and self.get_attr(Algorithm).has_authentication():
             raise ValueError("Algorithems that support authentication must be placed in the protected header.")
 
+        if not self.get_attr(Algorithm).has_authentication() and len(self.phdr) > 0:
+            raise ValueError("Protected header must be empty when the algorithm does not support authentication.")
+
         if encrypt:
             message = [self.phdr_encoded, self.uhdr_encoded, self.encrypt()]
         else:

--- a/pycose/messages/encmessage.py
+++ b/pycose/messages/encmessage.py
@@ -64,6 +64,10 @@ class EncMessage(enccommon.EncCommon):
         if Algorithm in self.uhdr and self.get_attr(headers.Algorithm).has_authentication():
             raise ValueError("Algorithems that support authentication must be placed in the protected header.")
 
+        if not self.get_attr(Algorithm).has_authentication() and len(self.phdr) > 0:
+            raise ValueError("Protected header must be empty when the algorithm does not support authentication.")
+
+
         # encode/wrap_cek the base fields
         if encrypt:
             message = [self.phdr_encoded, self.uhdr_encoded, self.encrypt()]

--- a/pycose/messages/encmessage.py
+++ b/pycose/messages/encmessage.py
@@ -2,6 +2,7 @@ import os
 from typing import List, Optional, TYPE_CHECKING
 
 from pycose import utils, headers
+from pycose.headers import Algorithm
 from pycose.exceptions import CoseException
 from pycose.keys.keyops import EncryptOp
 from pycose.keys.keyparam import KpAlg, KpKeyOps
@@ -59,6 +60,9 @@ class EncMessage(enccommon.EncCommon):
 
     def encode(self, tag: bool = True, encrypt: bool = True, *args, **kwargs) -> CBOR:
         """ Encodes and protects the COSE_Encrypt message """
+
+        if Algorithm in self.uhdr and self.get_attr(headers.Algorithm).has_authentication():
+            raise ValueError("Algorithems that support authentication must be placed in the protected header.")
 
         # encode/wrap_cek the base fields
         if encrypt:

--- a/pycose/messages/mac0message.py
+++ b/pycose/messages/mac0message.py
@@ -10,6 +10,7 @@
 from typing import Optional, TYPE_CHECKING
 
 from pycose import utils
+from pycose.headers import Algorithm
 from pycose.messages import cosemessage, maccommon
 
 if TYPE_CHECKING:
@@ -41,6 +42,9 @@ class Mac0Message(maccommon.MacCommon):
 
     def encode(self, tag: bool = True, mac: bool = True, *args, **kwargs) -> bytes:
         """ Encode and protect the COSE_Mac0 message. """
+
+        if Algorithm in self.uhdr:
+            raise ValueError("MAC-Algorithems are not supposed to be placed in the unprotected header.")
 
         if mac:
             message = [self.phdr_encoded, self.uhdr_encoded, self.payload, self.compute_tag()]

--- a/pycose/messages/macmessage.py
+++ b/pycose/messages/macmessage.py
@@ -61,6 +61,9 @@ class MacMessage(maccommon.MacCommon):
     def encode(self, tag: bool = True, mac: bool = True, *args, **kwargs) -> CBOR:
         """ Encodes and protects the COSE_Mac message. """
 
+        if headers.Algorithm in self.uhdr:
+            raise ValueError("MAC-Algorithems are not supposed to be placed in the unprotected header.")
+
         if mac:
             message = [self.phdr_encoded, self.uhdr_encoded, self.payload, self.compute_tag()]
         else:

--- a/pycose/messages/sign1message.py
+++ b/pycose/messages/sign1message.py
@@ -3,6 +3,7 @@ from typing import Optional, Union, TYPE_CHECKING
 import cbor2
 
 from pycose import utils
+from pycose.headers import Algorithm
 from pycose.messages.cosemessage import CoseMessage
 from pycose.messages.signcommon import SignCommon
 from pycose.exceptions import CoseException
@@ -72,6 +73,11 @@ class Sign1Message(SignCommon):
 
     def encode(self, tag: bool = True, sign: bool = True, detached_payload: Optional[bytes] = None, *args, **kwargs) -> CBOR:
         """ Encodes the message into a CBOR array with or without a CBOR tag. """
+
+
+        if Algorithm in self.uhdr:
+            raise ValueError("Signing Algorithems are not supposed to be placed in the unprotected header.")
+
 
         if sign:
             message = [self.phdr_encoded, self.uhdr_encoded, self.payload, self.compute_signature(detached_payload)]

--- a/pycose/messages/signmessage.py
+++ b/pycose/messages/signmessage.py
@@ -11,6 +11,7 @@ import cbor2
 
 from pycose import utils
 from pycose.exceptions import CoseException
+from pycose.headers import Algorithm
 from pycose.messages.cosemessage import CoseMessage
 from pycose.messages.signer import CoseSignature
 
@@ -73,6 +74,9 @@ class _SignMessage(CoseMessage, metaclass=abc.ABCMeta):
 
     def encode(self, tag: bool = True, detached_payload: Optional[bytes] = None, *args, **kwargs) -> bytes:
         """ Encodes and protects the COSE_Sign message. """
+
+        if Algorithm in self.uhdr:
+            raise ValueError("Signing Algorithems are not supposed to be placed in the unprotected header.")
 
         message = [self.phdr_encoded, self.uhdr_encoded, self.payload]
 


### PR DESCRIPTION
I've added some improvements to pycose:

- Updated the README file.
- Added a check for the `content-type` parameter — RFC 9052 says it can't have leading or trailing spaces and must follow the `<type-name>/<subtype-name>` format.
- Added checks to make sure the user can't put the `alg` and `crit` header parameters in the unprotected header, as per RFC 9052.
- Added checks to ensure correct usage of nonces and key lengths, following RFC 9053.
