### PR TITLE
Updates to fix CI jobs including tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -124,5 +124,7 @@ jobs:
         pip install twine
     
     - name: Upload package to PyPI
+      env:
+        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       run: |
-        twine upload -u __token__ -p ${{ secrets.PYPI_TOKEN }} --skip-existing dist/*
+        twine upload -u __token__ -p "$PYPI_TOKEN" --skip-existing dist/*

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout project

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -62,9 +62,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - name: Checkout project

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,7 +29,7 @@ jobs:
         python -m build
     
     - name: Upload package to artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/
@@ -71,7 +71,7 @@ jobs:
       uses: actions/checkout@v3
     
     - name: Download package from artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist
@@ -105,7 +105,7 @@ jobs:
 
     steps:
     - name: Download package from artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -85,6 +85,9 @@ jobs:
     - name: Install test dependencies
       run: |
         pip install pytest
+        # work around lack of release version fix for oscrypto issue #75
+        # https://github.com/wbond/oscrypto/pull/76
+        pip install --user --force-reinstall --break-system-packages git+https://github.com/wbond/oscrypto.git@master
 
     - name: Install package
       run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts = -ra -v -x
+addopts = -ra -v
 testpaths =
     tests

--- a/tests/test_ec2_keys.py
+++ b/tests/test_ec2_keys.py
@@ -200,7 +200,7 @@ def test_fail_on_illegal_kty(crv, kty):
 
 
 def test_remove_empty_keyops_list():
-    cose_key = {KpKty: KtyEC2, EC2KpD: p384_d, KpAlg: Es256, EC2KpCurve: P256, KpKeyOps: []}
+    cose_key = {KpKty: KtyEC2, EC2KpD: p256_d, KpAlg: Es256, EC2KpCurve: P256, KpKeyOps: []}
 
     key = CoseKey.from_dict(cose_key)
 

--- a/tests/test_rsa_keys.py
+++ b/tests/test_rsa_keys.py
@@ -12,12 +12,12 @@ from pycose.keys.keyparam import KpKty, RSAKpE, RSAKpN, KpAlg, KpKeyOps, RSAKpD
 from pycose.keys.keytype import KtySymmetric, KtyOKP, KtyEC2, KtyRSA
 
 
-@pytest.mark.parametrize('bit_length', [512, 1024, 2048, 4096])
+@pytest.mark.parametrize('bit_length', [1024, 2048, 4096])
 def test_rsa_key_generation(bit_length):
     key = RSAKey.generate_key(bit_length)
 
 
-@pytest.mark.parametrize('bit_length', [512, 1024])
+@pytest.mark.parametrize('bit_length', [1024])
 @pytest.mark.parametrize('kty', [KtyOKP, KtySymmetric, KtyEC2, 1, 4])
 def test_fail_on_illegal_kty(bit_length, kty):
     params = {KpKty: kty}


### PR DESCRIPTION
Part of this update bumps github actions from earlier, deprecated versions.

This includes a necessary workaround on ubuntu-24.04 for [bug in last released `oscrypto` library](https://github.com/wbond/oscrypto/issues/75).