### PR TITLE
Allow symmetric key to be any non-empty bytes

### DIFF
--- a/pycose/algorithms.py
+++ b/pycose/algorithms.py
@@ -42,6 +42,12 @@ class CoseAlgorithm(_CoseAttribute, ABC):
     def get_registered_classes(cls):
         return cls._registered_algorithms
 
+    @staticmethod
+    def _check_key_len(need: int, have: int):
+        ''' Common function to check needed key length '''
+        if have != need:
+            raise CoseException(f'Invalid key length, need {need} have {have}')
+
 
 class _HashAlg(CoseAlgorithm, ABC):
     #: Set in derived class to hash constructor
@@ -205,6 +211,7 @@ class _AesMac(CoseAlgorithm, ABC):
 
     @classmethod
     def compute_tag(cls, key: 'SK', data: bytes):
+        cls._check_key_len(cls.get_key_length(), len(key.k))
         encryptor = Cipher(AES(key.k),
                            modes.CBC(unhexlify(b''.join([b'00'] * 16))),
                            backend=default_backend()).encryptor()
@@ -314,11 +321,13 @@ class _AesGcm(_EncAlg, ABC):
 
     @classmethod
     def encrypt(cls, key: 'SK', nonce: bytes, data: bytes, aad: bytes) -> bytes:
+        cls._check_key_len(cls.get_key_length(), len(key.k))
         cipher = AESGCM(key=key.k)
         return cipher.encrypt(nonce=nonce, data=data, associated_data=aad)
 
     @classmethod
     def decrypt(cls, key: 'SK', nonce: bytes, ciphertext: bytes, aad: bytes) -> bytes:
+        cls._check_key_len(cls.get_key_length(), len(key.k))
         cipher = AESGCM(key=key.k)
         return cipher.decrypt(nonce=nonce, data=ciphertext, associated_data=aad)
 
@@ -332,11 +341,13 @@ class _AesCcm(_EncAlg, ABC):
 
     @classmethod
     def encrypt(cls, key: 'SK', nonce: bytes, data: bytes, aad: bytes) -> bytes:
+        cls._check_key_len(cls.get_key_length(), len(key.k))
         cipher = AESCCM(key.k, tag_length=cls.get_tag_length())
         return cipher.encrypt(nonce, data=data, associated_data=aad)
 
     @classmethod
     def decrypt(cls, key: 'SK', nonce: bytes, ciphertext: bytes, aad: bytes) -> bytes:
+        cls._check_key_len(cls.get_key_length(), len(key.k))
         cipher = AESCCM(key=key.k, tag_length=cls.get_tag_length())
         return cipher.decrypt(nonce, data=ciphertext, associated_data=aad)
 

--- a/pycose/keys/symmetric.py
+++ b/pycose/keys/symmetric.py
@@ -65,10 +65,7 @@ class SymmetricKey(CoseKey):
 
         super(SymmetricKey, self).__init__(transformed_dict)
 
-        if k != b'':
-            self.k = k
-        else:
-            raise CoseInvalidKey("SymKpK parameter cannot be None")
+        self.k = k
 
     def __delitem__(self, key):
         if self._key_transform(key) != KpKty and self._key_transform(key) != SymKpK:
@@ -88,8 +85,8 @@ class SymmetricKey(CoseKey):
     def k(self, k: bytes):
         if type(k) is not bytes:
             raise ValueError("SymKpK parameter must be of type 'bytes'")
-        if len(k) not in [16, 24, 32]:
-            raise CoseInvalidKey("Key length should be either 16, 24, or 32 bytes")
+        if len(k) == 0:
+            raise CoseInvalidKey("SymKpK parameter must be non-empty")
         self.store[SymKpK] = k
 
     @property

--- a/tests/test_symmetric_keys.py
+++ b/tests/test_symmetric_keys.py
@@ -86,17 +86,17 @@ def test_fail_on_missing_symmetric_kty(length):
 
 
 def test_fail_on_invalid_symmetric_key_length():
-    cose_key = {KpKty: KtySymmetric, SymKpK: os.urandom(17)}
+    cose_key = {KpKty: KtySymmetric, SymKpK: b''}
 
     with pytest.raises(CoseInvalidKey) as excinfo:
         CoseKey.from_dict(cose_key)
 
-    assert "Key length should be either 16, 24, or 32 bytes" in str(excinfo.value)
+    assert "SymKpK parameter must be non-empty" in str(excinfo.value)
 
     with pytest.raises(CoseInvalidKey) as excinfo:
-        _ = SymmetricKey(k=os.urandom(17))
+        _ = SymmetricKey(k=b'')
 
-    assert "Key length should be either 16, 24, or 32 bytes" in str(excinfo.value)
+    assert "SymKpK parameter must be non-empty" in str(excinfo.value)
 
 
 def test_fail_on_missing_symkpk():
@@ -105,7 +105,7 @@ def test_fail_on_missing_symkpk():
     with pytest.raises(CoseInvalidKey) as excinfo:
         CoseKey.from_dict(cose_key)
 
-    assert "SymKpK parameter cannot be None" in str(excinfo.value)
+    assert "SymKpK parameter must be non-empty" in str(excinfo.value)
 
 
 def test_remove_empty_keyops_list():


### PR DESCRIPTION
This closes #112 and closes #133 and adds algorithm-specific checks for key length.

The HMAC algorithms do not require an exact or minimum length because of the requirements of [RFC 9053](https://www.rfc-editor.org/rfc/rfc9053.html#section-3.1) state:

> For those algorithms that transport the key (such as AES Key Wrap), the size of the HMAC key SHOULD be the same size as the output of the underlying hash function.
> For those algorithms that derive the key (such as ECDH), the derived key MUST be the same size as the output of the underlying hash function.